### PR TITLE
Atvdetails more instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,10 @@ Steps to be taken to update Stats depend on changes made, to make sure that you 
 ### 7 Note
 
 - Not all information stored in tables stats_worker and stats_area is included in Stats menu options, adapt as you see fit. <br>
-- Menu option 30 contains several queries regarding device setting/information but requires https://github.com/dkmur/ATVdetails <br>
 
 
 
-## Meaning of Stats columns
+## Meaning of Stats columns (tables stats_area and stats_worker)
 
 
 **RPL** Report Length Period : will be 15, 60, 1440 or 10080 minutes  

--- a/cron_files/atvdetails.sh
+++ b/cron_files/atvdetails.sh
@@ -1,0 +1,469 @@
+#!/bin/bash
+
+folder="$(cd ../ && pwd)"
+source $folder/config.ini
+
+
+## update db for instance 1
+if [ -z "$MAD_path_1" ]; then
+        echo ""
+	echo "No instance defined"
+else
+	echo "Inserting origins into table"
+	echo ""
+	mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "insert ignore into ATVdetails (date,origin) select curdate(), name from $MAD_DB.settings_device;"
+        echo "Starting jobs for instance 1"
+	echo ""
+	cp $PATH_TO_STATS/default_files/ATVdetails.json $MAD_path_1/personal_commands/
+	curl -u $MADmin_username_1:$MADmin_password_1 "$MAD_url_1/delete_log"
+	curl -u $MADmin_username_1:$MADmin_password_1 "$MAD_url_1/reload_jobs"
+	curl -u $MADmin_username_1:$MADmin_password_1 "$MAD_url_1/install_file_all_devices?jobname=ATVdetails&type=jobType.CHAIN"
+	echo ""
+	echo "Wait timer started"
+	sleep $job_wait
+	echo ""
+	echo "Start processing jobs instance 1"
+        mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "insert ignore into ATVdetails (date,origin) select curdate(), name from $MAD_DB.settings_device;"
+
+        query(){
+        mysql -u$SQL_user -p$SQL_password -NB -h$DB_IP -P$DB_PORT $STATS_DB -e "$1;"
+        }
+        while read -r origin _ ;do
+        arch=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=ARCH=).*?(?= )')
+        rgc=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC=).*?(?= )')
+        pogodroid=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD=).*?(?= )')
+        pogo=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PoGo=).*?(?= )')
+        rom=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=ROM=).*?(?= )')
+        pogo_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PoGo_Autoupdate=).*?(?= )')
+        rgc_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_Autoupdate=).*?(?= )')
+        pd_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_Autoupdate=).*?(?= )')
+        pingreboot=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=Pingreboot=).*?(?= )')
+        temperature=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=Temperature=).*?(?= )')
+        Magisk=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=Magisk=).*?(?= )')
+        Modules=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=Modules=).*?(?= Gmail)')
+        IP=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=IP=).*?(?= )')
+        Gmail=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=Gmail=).*?(?= )')
+        PD_auth_username=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_auth_username=).*?(?= )')
+        PD_auth_password=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_auth_password=).*?(?= )')
+        PD_user_login=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_user_id=).*?(?= )')
+        PD_auth_id=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_auth_id=).*?(?= )')
+        PD_auth_token=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_auth_token=).*?(?= )')
+        PD_post_destination=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_post_destination=).*?(?= )' | sed 's/, //')
+        PD_boot_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_boot_delay=).*?(?= )')
+        PD_injection_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_preference_inject_after_seconds=).*?(?= )')
+	PD_switch_disable_last_sent=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_switch_disable_last_sent=).*?(?= )')
+	PD_intentional_stop=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_intentional_stop=).*?(?= )')
+	PD_switch_send_protos=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_switch_send_protos=).*?(?= )')
+	PD_last_time_injected=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_last_time_injected=).*?(?= )')
+	PD_switch_disable_external_communication=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_switch_disable_external_communication=).*?(?= )')
+	PD_last_pid_injected=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_last_pid_injected=).*?(?= )')
+	PD_switch_enable_oomadj=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_switch_enable_oomadj=).*?(?= )')
+	PD_switch_enable_auth_header=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_switch_enable_auth_header=).*?(?= )')
+	PD_switch_send_raw_protos=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_switch_send_raw_protos=).*?(?= )')
+	PD_switch_popup_last_sent=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_switch_popup_last_sent=).*?(?= )')
+	PD_full_daemon=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_full_daemon=).*?(?= )')
+        PD_disable_pogo_freeze_detection=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_disable_pogo_freeze_detection=).*?(?= )')
+	PD_switch_enable_mock_location_patch=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_switch_enable_mock_location_patch=).*?(?= )')
+	PD_last_system_patch_timestamp=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_last_system_patch_timestamp=).*?(?= )')
+	PD_last_sys_inj=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_last_sys_inj=).*?(?= )')
+	PD_default_mappging_mode=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_default_mappging_mode=).*?(?= )')
+	PD_switch_setenforce=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_switch_setenforce=).*?(?= )')
+	PD_post_destination_raw=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_post_destination_raw=).*?(?= )')
+	PD_session_id=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_session_id=).*?(?= )')
+	PD_libfilename=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_libfilename=).*?(?= )')
+	PD_latest_version_known=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=PD_latest_version_known=).*?(?= )')
+        RGC_auth_username=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_auth_username=).*?(?= )')
+        RGC_auth_password=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_auth_password=).*?(?= )')
+        RGC_websocket_uri=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_websocket_uri=).*?(?= )')
+        RGC_boot_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_boot_delay=).*?(?= )')
+	RGC_mediaprojection_previously_started=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_mediaprojection_previously_started=).*?(?= )')
+	RGC_suspended_mocking=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_suspended_mocking=).*?(?= )')
+	RGC_reset_agps_once=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_reset_agps_once=).*?(?= )')
+	RGC_overwrite_fused=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_overwrite_fused=).*?(?= )')
+	RGC_switch_enable_auth_header=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_switch_enable_auth_header=).*?(?= )')
+	RGC_reset_agps_continuously=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_reset_agps_continuously=).*?(?= )')
+	RGC_reset_google_play_services=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_reset_google_play_services=).*?(?= )')
+	RGC_last_location_longitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_last_location_longitude=).*?(?= )')
+	RGC_last_location_altitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_last_location_altitude=).*?(?= )')
+	RGC_last_location_latitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_last_location_latitude=).*?(?= )')
+	RGC_boot_startup=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_boot_startup=).*?(?= )')
+	RGC_use_mock_location=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_use_mock_location=).*?(?= )')
+	RGC_oom_adj_override=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_oom_adj_override=).*?(?= )')
+	RGC_location_reporter_service_running=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_location_reporter_service_running=).*?(?= )')
+	RGC_stop_location_provider_service=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_stop_location_provider_service=).*?(?= )')
+	RGC_autostart_services=$(grep -w RGC_websocket_origin=$origin $MAD_path_1/update_log.json| grep -o -P '(?<=RGC_autostart_services=).*?(?= )')
+
+        if [ "$rgc" != '' ]; then
+                mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "UPDATE ATVdetails set arch = '$arch', rgc = '$rgc', pogodroid = '$pogodroid', pogo = '$pogo', rom = '$rom', magisk = '$Magisk', pogo_update = '$pogo_update', rgc_update = '$rgc_update', pd_update = '$pd_update', pingreboot = '$pingreboot', temperature = '$temperature', magisk_modules = '$Modules', ip = '$IP', gmail = '$Gmail', PD_auth_username = '$PD_auth_username', PD_auth_password = '$PD_auth_password', PD_user_login = '$PD_user_login', PD_auth_id = '$PD_auth_id', PD_auth_token = '$PD_auth_token', PD_post_destination = '$PD_post_destination', PD_boot_delay = '$PD_boot_delay', PD_injection_delay = '$PD_injection_delay', PD_switch_disable_last_sent = '$PD_switch_disable_last_sent', PD_intentional_stop = '$PD_intentional_stop', PD_switch_send_protos = '$PD_switch_send_protos', PD_last_time_injected = '$PD_last_time_injected', PD_switch_disable_external_communication = '$PD_switch_disable_external_communication', PD_last_pid_injected = '$PD_last_pid_injected', PD_switch_enable_oomadj = '$PD_switch_enable_oomadj', PD_switch_enable_auth_header = '$PD_switch_enable_auth_header', PD_switch_send_raw_protos = '$PD_switch_send_raw_protos', PD_switch_popup_last_sent = '$PD_switch_popup_last_sent', PD_full_daemon = '$PD_full_daemon', PD_switch_enable_mock_location_patch = '$PD_switch_enable_mock_location_patch', PD_last_system_patch_timestamp = '$PD_last_system_patch_timestamp', PD_last_sys_inj = '$PD_last_sys_inj', PD_default_mappging_mode = '$PD_default_mappging_mode', PD_switch_setenforce = '$PD_switch_setenforce', PD_post_destination_raw = '$PD_post_destination_raw', PD_session_id = '$PD_session_id', PD_libfilename = '$PD_libfilename', PD_latest_version_known = '$PD_latest_version_known', PD_disable_pogo_freeze_detection = '$PD_disable_pogo_freeze_detection', RGC_auth_username = '$RGC_auth_username', RGC_auth_password = '$RGC_auth_password', RGC_websocket_uri = '$RGC_websocket_uri', RGC_boot_delay = '$RGC_boot_delay', RGC_mediaprojection_previously_started = '$RGC_mediaprojection_previously_started', RGC_suspended_mocking = '$RGC_suspended_mocking', RGC_reset_agps_once = '$RGC_reset_agps_once', RGC_overwrite_fused = '$RGC_overwrite_fused', RGC_switch_enable_auth_header = '$RGC_switch_enable_auth_header', RGC_reset_agps_continuously = '$RGC_reset_agps_continuously', RGC_reset_google_play_services = '$RGC_reset_google_play_services', RGC_last_location_longitude = '$RGC_last_location_longitude', RGC_last_location_altitude = '$RGC_last_location_altitude', RGC_last_location_latitude = '$RGC_last_location_latitude', RGC_boot_startup = '$RGC_boot_startup', RGC_use_mock_location = '$RGC_use_mock_location', RGC_oom_adj_override = '$RGC_oom_adj_override',  RGC_location_reporter_service_running = '$RGC_location_reporter_service_running', RGC_stop_location_provider_service = '$RGC_stop_location_provider_service', RGC_autostart_services = '$RGC_autostart_services'  WHERE origin = '$origin' and date = curdate();"
+        fi
+        done < <(query "select origin FROM ATVdetails where date = curdate();")
+fi
+
+## update db for instance 2
+if [ -z "$MAD_path_2" ]; then
+        echo ""
+        echo "No 2nd instance defined"
+else
+        echo "Starting jobs for instance 2"
+        echo ""
+        cp $PATH_TO_STATS/default_files/ATVdetails.json $MAD_path_2/personal_commands/
+        curl -u $MADmin_username_2:$MADmin_password_2 "$MAD_url_2/delete_log"
+        curl -u $MADmin_username_2:$MADmin_password_2 "$MAD_url_2/reload_jobs"
+        curl -u $MADmin_username_2:$MADmin_password_2 "$MAD_url_2/install_file_all_devices?jobname=ATVdetails&type=jobType.CHAIN"
+        echo ""
+        echo "Wait timer started"
+        sleep $job_wait
+        echo ""
+        echo "Start processing jobs instance 2"
+        mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "insert ignore into ATVdetails (date,origin) select curdate(), name from $MAD_DB.settings_device;"
+
+        query(){
+        mysql -u$SQL_user -p$SQL_password -NB -h$DB_IP -P$DB_PORT $STATS_DB -e "$1;"
+        }
+        while read -r origin _ ;do
+        arch=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=ARCH=).*?(?= )')
+        rgc=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC=).*?(?= )')
+        pogodroid=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD=).*?(?= )')
+        pogo=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PoGo=).*?(?= )')
+        rom=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=ROM=).*?(?= )')
+        pogo_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PoGo_Autoupdate=).*?(?= )')
+        rgc_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_Autoupdate=).*?(?= )')
+        pd_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_Autoupdate=).*?(?= )')
+        pingreboot=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=Pingreboot=).*?(?= )')
+        temperature=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=Temperature=).*?(?= )')
+        Magisk=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=Magisk=).*?(?= )')
+        Modules=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=Modules=).*?(?= Gmail)')
+        IP=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=IP=).*?(?= )')
+        Gmail=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=Gmail=).*?(?= )')
+        PD_auth_username=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_auth_username=).*?(?= )')
+        PD_auth_password=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_auth_password=).*?(?= )')
+        PD_user_login=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_user_id=).*?(?= )')
+        PD_auth_id=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_auth_id=).*?(?= )')
+        PD_auth_token=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_auth_token=).*?(?= )')
+        PD_post_destination=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_post_destination=).*?(?= )' | sed 's/, //')
+        PD_boot_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_boot_delay=).*?(?= )')
+        PD_injection_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_preference_inject_after_seconds=).*?(?= )')
+        PD_switch_disable_last_sent=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_switch_disable_last_sent=).*?(?= )')
+        PD_intentional_stop=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_intentional_stop=).*?(?= )')
+        PD_switch_send_protos=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_switch_send_protos=).*?(?= )')
+        PD_last_time_injected=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_last_time_injected=).*?(?= )')
+        PD_switch_disable_external_communication=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_switch_disable_external_communication=).*?(?= )')
+        PD_last_pid_injected=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_last_pid_injected=).*?(?= )')
+        PD_switch_enable_oomadj=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_switch_enable_oomadj=).*?(?= )')
+        PD_switch_enable_auth_header=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_switch_enable_auth_header=).*?(?= )')
+        PD_switch_send_raw_protos=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_switch_send_raw_protos=).*?(?= )')
+        PD_switch_popup_last_sent=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_switch_popup_last_sent=).*?(?= )')
+        PD_full_daemon=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_full_daemon=).*?(?= )')
+        PD_disable_pogo_freeze_detection=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_disable_pogo_freeze_detection=).*?(?= )')
+        PD_switch_enable_mock_location_patch=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_switch_enable_mock_location_patch=).*?(?= )')
+        PD_last_system_patch_timestamp=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_last_system_patch_timestamp=).*?(?= )')
+        PD_last_sys_inj=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_last_sys_inj=).*?(?= )')
+        PD_default_mappging_mode=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_default_mappging_mode=).*?(?= )')
+        PD_switch_setenforce=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_switch_setenforce=).*?(?= )')
+        PD_post_destination_raw=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_post_destination_raw=).*?(?= )')
+        PD_session_id=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_session_id=).*?(?= )')
+        PD_libfilename=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_libfilename=).*?(?= )')
+        PD_latest_version_known=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=PD_latest_version_known=).*?(?= )')
+        RGC_auth_username=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_auth_username=).*?(?= )')
+        RGC_auth_password=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_auth_password=).*?(?= )')
+        RGC_websocket_uri=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_websocket_uri=).*?(?= )')
+        RGC_boot_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_boot_delay=).*?(?= )')
+        RGC_mediaprojection_previously_started=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_mediaprojection_previously_started=).*?(?= )')
+        RGC_suspended_mocking=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_suspended_mocking=).*?(?= )')
+        RGC_reset_agps_once=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_reset_agps_once=).*?(?= )')
+        RGC_overwrite_fused=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_overwrite_fused=).*?(?= )')
+        RGC_switch_enable_auth_header=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_switch_enable_auth_header=).*?(?= )')
+        RGC_reset_agps_continuously=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_reset_agps_continuously=).*?(?= )')
+        RGC_reset_google_play_services=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_reset_google_play_services=).*?(?= )')
+        RGC_last_location_longitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_last_location_longitude=).*?(?= )')
+        RGC_last_location_altitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_last_location_altitude=).*?(?= )')
+        RGC_last_location_latitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_last_location_latitude=).*?(?= )')
+        RGC_boot_startup=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_boot_startup=).*?(?= )')
+        RGC_use_mock_location=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_use_mock_location=).*?(?= )')
+        RGC_oom_adj_override=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_oom_adj_override=).*?(?= )')
+        RGC_location_reporter_service_running=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_location_reporter_service_running=).*?(?= )')
+        RGC_stop_location_provider_service=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_stop_location_provider_service=).*?(?= )')
+        RGC_autostart_services=$(grep -w RGC_websocket_origin=$origin $MAD_path_2/update_log.json| grep -o -P '(?<=RGC_autostart_services=).*?(?= )')
+
+        if [ "$rgc" != '' ]; then
+                mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "UPDATE ATVdetails set arch = '$arch', rgc = '$rgc', pogodroid = '$pogodroid', pogo = '$pogo', rom = '$rom', magisk = '$Magisk', pogo_update = '$pogo_update', rgc_update = '$rgc_update', pd_update = '$pd_update', pingreboot = '$pingreboot', temperature = '$temperature', magisk_modules = '$Modules', ip = '$IP', gmail = '$Gmail', PD_auth_username = '$PD_auth_username', PD_auth_password = '$PD_auth_password', PD_user_login = '$PD_user_login', PD_auth_id = '$PD_auth_id', PD_auth_token = '$PD_auth_token', PD_post_destination = '$PD_post_destination', PD_boot_delay = '$PD_boot_delay', PD_injection_delay = '$PD_injection_delay', PD_switch_disable_last_sent = '$PD_switch_disable_last_sent', PD_intentional_stop = '$PD_intentional_stop', PD_switch_send_protos = '$PD_switch_send_protos', PD_last_time_injected = '$PD_last_time_injected', PD_switch_disable_external_communication = '$PD_switch_disable_external_communication', PD_last_pid_injected = '$PD_last_pid_injected', PD_switch_enable_oomadj = '$PD_switch_enable_oomadj', PD_switch_enable_auth_header = '$PD_switch_enable_auth_header', PD_switch_send_raw_protos = '$PD_switch_send_raw_protos', PD_switch_popup_last_sent = '$PD_switch_popup_last_sent', PD_full_daemon = '$PD_full_daemon', PD_switch_enable_mock_location_patch = '$PD_switch_enable_mock_location_patch', PD_last_system_patch_timestamp = '$PD_last_system_patch_timestamp', PD_last_sys_inj = '$PD_last_sys_inj', PD_default_mappging_mode = '$PD_default_mappging_mode', PD_switch_setenforce = '$PD_switch_setenforce', PD_post_destination_raw = '$PD_post_destination_raw', PD_session_id = '$PD_session_id', PD_libfilename = '$PD_libfilename', PD_latest_version_known = '$PD_latest_version_known', PD_disable_pogo_freeze_detection = '$PD_disable_pogo_freeze_detection', RGC_auth_username = '$RGC_auth_username', RGC_auth_password = '$RGC_auth_password', RGC_websocket_uri = '$RGC_websocket_uri', RGC_boot_delay = '$RGC_boot_delay', RGC_mediaprojection_previously_started = '$RGC_mediaprojection_previously_started', RGC_suspended_mocking = '$RGC_suspended_mocking', RGC_reset_agps_once = '$RGC_reset_agps_once', RGC_overwrite_fused = '$RGC_overwrite_fused', RGC_switch_enable_auth_header = '$RGC_switch_enable_auth_header', RGC_reset_agps_continuously = '$RGC_reset_agps_continuously', RGC_reset_google_play_services = '$RGC_reset_google_play_services', RGC_last_location_longitude = '$RGC_last_location_longitude', RGC_last_location_altitude = '$RGC_last_location_altitude', RGC_last_location_latitude = '$RGC_last_location_latitude', RGC_boot_startup = '$RGC_boot_startup', RGC_use_mock_location = '$RGC_use_mock_location', RGC_oom_adj_override = '$RGC_oom_adj_override',  RGC_location_reporter_service_running = '$RGC_location_reporter_service_running', RGC_stop_location_provider_service = '$RGC_stop_location_provider_service', RGC_autostart_services = '$RGC_autostart_services'  WHERE origin = '$origin' and date = curdate();"
+        fi
+        done < <(query "select origin FROM ATVdetails where date = curdate();")
+fi
+
+## update db for instance 3
+if [ -z "$MAD_path_3" ]; then
+        echo ""
+        echo "No 3rd instance defined"
+else
+        echo "Starting jobs for instance 3"
+        echo ""
+        cp $PATH_TO_STATS/default_files/ATVdetails.json $MAD_path_3/personal_commands/
+        curl -u $MADmin_username_3:$MADmin_password_3 "$MAD_url_3/delete_log"
+        curl -u $MADmin_username_3:$MADmin_password_3 "$MAD_url_3/reload_jobs"
+        curl -u $MADmin_username_3:$MADmin_password_3 "$MAD_url_3/install_file_all_devices?jobname=ATVdetails&type=jobType.CHAIN"
+        echo ""
+        echo "Wait timer started"
+        sleep $job_wait
+        echo ""
+        echo "Start processing jobs instance 3"
+        mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "insert ignore into ATVdetails (date,origin) select curdate(), name from $MAD_DB.settings_device;"
+
+        query(){
+        mysql -u$SQL_user -p$SQL_password -NB -h$DB_IP -P$DB_PORT $STATS_DB -e "$1;"
+        }
+        while read -r origin _ ;do
+        arch=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=ARCH=).*?(?= )')
+        rgc=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC=).*?(?= )')
+        pogodroid=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD=).*?(?= )')
+        pogo=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PoGo=).*?(?= )')
+        rom=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=ROM=).*?(?= )')
+        pogo_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PoGo_Autoupdate=).*?(?= )')
+        rgc_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_Autoupdate=).*?(?= )')
+        pd_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_Autoupdate=).*?(?= )')
+        pingreboot=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=Pingreboot=).*?(?= )')
+        temperature=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=Temperature=).*?(?= )')
+        Magisk=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=Magisk=).*?(?= )')
+        Modules=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=Modules=).*?(?= Gmail)')
+        IP=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=IP=).*?(?= )')
+        Gmail=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=Gmail=).*?(?= )')
+        PD_auth_username=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_auth_username=).*?(?= )')
+        PD_auth_password=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_auth_password=).*?(?= )')
+        PD_user_login=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_user_id=).*?(?= )')
+        PD_auth_id=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_auth_id=).*?(?= )')
+        PD_auth_token=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_auth_token=).*?(?= )')
+        PD_post_destination=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_post_destination=).*?(?= )' | sed 's/, //')
+        PD_boot_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_boot_delay=).*?(?= )')
+        PD_injection_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_preference_inject_after_seconds=).*?(?= )')
+        PD_switch_disable_last_sent=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_switch_disable_last_sent=).*?(?= )')
+        PD_intentional_stop=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_intentional_stop=).*?(?= )')
+        PD_switch_send_protos=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_switch_send_protos=).*?(?= )')
+        PD_last_time_injected=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_last_time_injected=).*?(?= )')
+        PD_switch_disable_external_communication=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_switch_disable_external_communication=).*?(?= )')
+        PD_last_pid_injected=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_last_pid_injected=).*?(?= )')
+        PD_switch_enable_oomadj=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_switch_enable_oomadj=).*?(?= )')
+        PD_switch_enable_auth_header=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_switch_enable_auth_header=).*?(?= )')
+        PD_switch_send_raw_protos=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_switch_send_raw_protos=).*?(?= )')
+        PD_switch_popup_last_sent=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_switch_popup_last_sent=).*?(?= )')
+        PD_full_daemon=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_full_daemon=).*?(?= )')
+        PD_disable_pogo_freeze_detection=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_disable_pogo_freeze_detection=).*?(?= )')
+        PD_switch_enable_mock_location_patch=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_switch_enable_mock_location_patch=).*?(?= )')
+        PD_last_system_patch_timestamp=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_last_system_patch_timestamp=).*?(?= )')
+        PD_last_sys_inj=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_last_sys_inj=).*?(?= )')
+        PD_default_mappging_mode=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_default_mappging_mode=).*?(?= )')
+        PD_switch_setenforce=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_switch_setenforce=).*?(?= )')
+        PD_post_destination_raw=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_post_destination_raw=).*?(?= )')
+        PD_session_id=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_session_id=).*?(?= )')
+        PD_libfilename=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_libfilename=).*?(?= )')
+        PD_latest_version_known=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=PD_latest_version_known=).*?(?= )')
+        RGC_auth_username=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_auth_username=).*?(?= )')
+        RGC_auth_password=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_auth_password=).*?(?= )')
+        RGC_websocket_uri=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_websocket_uri=).*?(?= )')
+        RGC_boot_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_boot_delay=).*?(?= )')
+        RGC_mediaprojection_previously_started=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_mediaprojection_previously_started=).*?(?= )')
+        RGC_suspended_mocking=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_suspended_mocking=).*?(?= )')
+        RGC_reset_agps_once=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_reset_agps_once=).*?(?= )')
+        RGC_overwrite_fused=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_overwrite_fused=).*?(?= )')
+        RGC_switch_enable_auth_header=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_switch_enable_auth_header=).*?(?= )')
+        RGC_reset_agps_continuously=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_reset_agps_continuously=).*?(?= )')
+        RGC_reset_google_play_services=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_reset_google_play_services=).*?(?= )')
+        RGC_last_location_longitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_last_location_longitude=).*?(?= )')
+        RGC_last_location_altitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_last_location_altitude=).*?(?= )')
+        RGC_last_location_latitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_last_location_latitude=).*?(?= )')
+        RGC_boot_startup=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_boot_startup=).*?(?= )')
+        RGC_use_mock_location=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_use_mock_location=).*?(?= )')
+        RGC_oom_adj_override=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_oom_adj_override=).*?(?= )')
+        RGC_location_reporter_service_running=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_location_reporter_service_running=).*?(?= )')
+        RGC_stop_location_provider_service=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_stop_location_provider_service=).*?(?= )')
+        RGC_autostart_services=$(grep -w RGC_websocket_origin=$origin $MAD_path_3/update_log.json| grep -o -P '(?<=RGC_autostart_services=).*?(?= )')
+
+        if [ "$rgc" != '' ]; then
+                mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "UPDATE ATVdetails set arch = '$arch', rgc = '$rgc', pogodroid = '$pogodroid', pogo = '$pogo', rom = '$rom', magisk = '$Magisk', pogo_update = '$pogo_update', rgc_update = '$rgc_update', pd_update = '$pd_update', pingreboot = '$pingreboot', temperature = '$temperature', magisk_modules = '$Modules', ip = '$IP', gmail = '$Gmail', PD_auth_username = '$PD_auth_username', PD_auth_password = '$PD_auth_password', PD_user_login = '$PD_user_login', PD_auth_id = '$PD_auth_id', PD_auth_token = '$PD_auth_token', PD_post_destination = '$PD_post_destination', PD_boot_delay = '$PD_boot_delay', PD_injection_delay = '$PD_injection_delay', PD_switch_disable_last_sent = '$PD_switch_disable_last_sent', PD_intentional_stop = '$PD_intentional_stop', PD_switch_send_protos = '$PD_switch_send_protos', PD_last_time_injected = '$PD_last_time_injected', PD_switch_disable_external_communication = '$PD_switch_disable_external_communication', PD_last_pid_injected = '$PD_last_pid_injected', PD_switch_enable_oomadj = '$PD_switch_enable_oomadj', PD_switch_enable_auth_header = '$PD_switch_enable_auth_header', PD_switch_send_raw_protos = '$PD_switch_send_raw_protos', PD_switch_popup_last_sent = '$PD_switch_popup_last_sent', PD_full_daemon = '$PD_full_daemon', PD_switch_enable_mock_location_patch = '$PD_switch_enable_mock_location_patch', PD_last_system_patch_timestamp = '$PD_last_system_patch_timestamp', PD_last_sys_inj = '$PD_last_sys_inj', PD_default_mappging_mode = '$PD_default_mappging_mode', PD_switch_setenforce = '$PD_switch_setenforce', PD_post_destination_raw = '$PD_post_destination_raw', PD_session_id = '$PD_session_id', PD_libfilename = '$PD_libfilename', PD_latest_version_known = '$PD_latest_version_known', PD_disable_pogo_freeze_detection = '$PD_disable_pogo_freeze_detection', RGC_auth_username = '$RGC_auth_username', RGC_auth_password = '$RGC_auth_password', RGC_websocket_uri = '$RGC_websocket_uri', RGC_boot_delay = '$RGC_boot_delay', RGC_mediaprojection_previously_started = '$RGC_mediaprojection_previously_started', RGC_suspended_mocking = '$RGC_suspended_mocking', RGC_reset_agps_once = '$RGC_reset_agps_once', RGC_overwrite_fused = '$RGC_overwrite_fused', RGC_switch_enable_auth_header = '$RGC_switch_enable_auth_header', RGC_reset_agps_continuously = '$RGC_reset_agps_continuously', RGC_reset_google_play_services = '$RGC_reset_google_play_services', RGC_last_location_longitude = '$RGC_last_location_longitude', RGC_last_location_altitude = '$RGC_last_location_altitude', RGC_last_location_latitude = '$RGC_last_location_latitude', RGC_boot_startup = '$RGC_boot_startup', RGC_use_mock_location = '$RGC_use_mock_location', RGC_oom_adj_override = '$RGC_oom_adj_override',  RGC_location_reporter_service_running = '$RGC_location_reporter_service_running', RGC_stop_location_provider_service = '$RGC_stop_location_provider_service', RGC_autostart_services = '$RGC_autostart_services'  WHERE origin = '$origin' and date = curdate();"
+        fi
+        done < <(query "select origin FROM ATVdetails where date = curdate();")
+fi
+
+## update db for instance 4
+if [ -z "$MAD_path_4" ]; then
+        echo ""
+        echo "No 4th instance defined"
+else
+        echo "Starting jobs for instance 4"
+        echo ""
+        cp $PATH_TO_STATS/default_files/ATVdetails.json $MAD_path_4/personal_commands/
+        curl -u $MADmin_username_4:$MADmin_password_4 "$MAD_url_4/delete_log"
+        curl -u $MADmin_username_4:$MADmin_password_4 "$MAD_url_4/reload_jobs"
+        curl -u $MADmin_username_4:$MADmin_password_4 "$MAD_url_4/install_file_all_devices?jobname=ATVdetails&type=jobType.CHAIN"
+        echo ""
+        echo "Wait timer started"
+        sleep $job_wait
+        echo ""
+        echo "Start processing jobs instance 4"
+        mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "insert ignore into ATVdetails (date,origin) select curdate(), name from $MAD_DB.settings_device;"
+
+        query(){
+        mysql -u$SQL_user -p$SQL_password -NB -h$DB_IP -P$DB_PORT $STATS_DB -e "$1;"
+        }
+        while read -r origin _ ;do
+        arch=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=ARCH=).*?(?= )')
+        rgc=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC=).*?(?= )')
+        pogodroid=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD=).*?(?= )')
+        pogo=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PoGo=).*?(?= )')
+        rom=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=ROM=).*?(?= )')
+        pogo_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PoGo_Autoupdate=).*?(?= )')
+        rgc_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_Autoupdate=).*?(?= )')
+        pd_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_Autoupdate=).*?(?= )')
+        pingreboot=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=Pingreboot=).*?(?= )')
+        temperature=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=Temperature=).*?(?= )')
+        Magisk=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=Magisk=).*?(?= )')
+        Modules=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=Modules=).*?(?= Gmail)')
+        IP=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=IP=).*?(?= )')
+        Gmail=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=Gmail=).*?(?= )')
+        PD_auth_username=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_auth_username=).*?(?= )')
+        PD_auth_password=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_auth_password=).*?(?= )')
+        PD_user_login=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_user_id=).*?(?= )')
+        PD_auth_id=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_auth_id=).*?(?= )')
+        PD_auth_token=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_auth_token=).*?(?= )')
+        PD_post_destination=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_post_destination=).*?(?= )' | sed 's/, //')
+        PD_boot_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_boot_delay=).*?(?= )')
+        PD_injection_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_preference_inject_after_seconds=).*?(?= )')
+        PD_switch_disable_last_sent=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_switch_disable_last_sent=).*?(?= )')
+        PD_intentional_stop=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_intentional_stop=).*?(?= )')
+        PD_switch_send_protos=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_switch_send_protos=).*?(?= )')
+        PD_last_time_injected=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_last_time_injected=).*?(?= )')
+        PD_switch_disable_external_communication=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_switch_disable_external_communication=).*?(?= )')
+        PD_last_pid_injected=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_last_pid_injected=).*?(?= )')
+        PD_switch_enable_oomadj=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_switch_enable_oomadj=).*?(?= )')
+        PD_switch_enable_auth_header=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_switch_enable_auth_header=).*?(?= )')
+        PD_switch_send_raw_protos=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_switch_send_raw_protos=).*?(?= )')
+        PD_switch_popup_last_sent=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_switch_popup_last_sent=).*?(?= )')
+        PD_full_daemon=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_full_daemon=).*?(?= )')
+        PD_disable_pogo_freeze_detection=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_disable_pogo_freeze_detection=).*?(?= )')
+        PD_switch_enable_mock_location_patch=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_switch_enable_mock_location_patch=).*?(?= )')
+        PD_last_system_patch_timestamp=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_last_system_patch_timestamp=).*?(?= )')
+        PD_last_sys_inj=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_last_sys_inj=).*?(?= )')
+        PD_default_mappging_mode=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_default_mappging_mode=).*?(?= )')
+        PD_switch_setenforce=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_switch_setenforce=).*?(?= )')
+        PD_post_destination_raw=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_post_destination_raw=).*?(?= )')
+        PD_session_id=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_session_id=).*?(?= )')
+        PD_libfilename=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_libfilename=).*?(?= )')
+        PD_latest_version_known=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=PD_latest_version_known=).*?(?= )')
+        RGC_auth_username=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_auth_username=).*?(?= )')
+        RGC_auth_password=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_auth_password=).*?(?= )')
+        RGC_websocket_uri=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_websocket_uri=).*?(?= )')
+        RGC_boot_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_boot_delay=).*?(?= )')
+        RGC_mediaprojection_previously_started=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_mediaprojection_previously_started=).*?(?= )')
+        RGC_suspended_mocking=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_suspended_mocking=).*?(?= )')
+        RGC_reset_agps_once=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_reset_agps_once=).*?(?= )')
+        RGC_overwrite_fused=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_overwrite_fused=).*?(?= )')
+        RGC_switch_enable_auth_header=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_switch_enable_auth_header=).*?(?= )')
+        RGC_reset_agps_continuously=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_reset_agps_continuously=).*?(?= )')
+        RGC_reset_google_play_services=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_reset_google_play_services=).*?(?= )')
+        RGC_last_location_longitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_last_location_longitude=).*?(?= )')
+        RGC_last_location_altitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_last_location_altitude=).*?(?= )')
+        RGC_last_location_latitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_last_location_latitude=).*?(?= )')
+        RGC_boot_startup=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_boot_startup=).*?(?= )')
+        RGC_use_mock_location=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_use_mock_location=).*?(?= )')
+        RGC_oom_adj_override=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_oom_adj_override=).*?(?= )')
+        RGC_location_reporter_service_running=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_location_reporter_service_running=).*?(?= )')
+        RGC_stop_location_provider_service=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_stop_location_provider_service=).*?(?= )')
+        RGC_autostart_services=$(grep -w RGC_websocket_origin=$origin $MAD_path_4/update_log.json| grep -o -P '(?<=RGC_autostart_services=).*?(?= )')
+
+        if [ "$rgc" != '' ]; then
+                mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "UPDATE ATVdetails set arch = '$arch', rgc = '$rgc', pogodroid = '$pogodroid', pogo = '$pogo', rom = '$rom', magisk = '$Magisk', pogo_update = '$pogo_update', rgc_update = '$rgc_update', pd_update = '$pd_update', pingreboot = '$pingreboot', temperature = '$temperature', magisk_modules = '$Modules', ip = '$IP', gmail = '$Gmail', PD_auth_username = '$PD_auth_username', PD_auth_password = '$PD_auth_password', PD_user_login = '$PD_user_login', PD_auth_id = '$PD_auth_id', PD_auth_token = '$PD_auth_token', PD_post_destination = '$PD_post_destination', PD_boot_delay = '$PD_boot_delay', PD_injection_delay = '$PD_injection_delay', PD_switch_disable_last_sent = '$PD_switch_disable_last_sent', PD_intentional_stop = '$PD_intentional_stop', PD_switch_send_protos = '$PD_switch_send_protos', PD_last_time_injected = '$PD_last_time_injected', PD_switch_disable_external_communication = '$PD_switch_disable_external_communication', PD_last_pid_injected = '$PD_last_pid_injected', PD_switch_enable_oomadj = '$PD_switch_enable_oomadj', PD_switch_enable_auth_header = '$PD_switch_enable_auth_header', PD_switch_send_raw_protos = '$PD_switch_send_raw_protos', PD_switch_popup_last_sent = '$PD_switch_popup_last_sent', PD_full_daemon = '$PD_full_daemon', PD_switch_enable_mock_location_patch = '$PD_switch_enable_mock_location_patch', PD_last_system_patch_timestamp = '$PD_last_system_patch_timestamp', PD_last_sys_inj = '$PD_last_sys_inj', PD_default_mappging_mode = '$PD_default_mappging_mode', PD_switch_setenforce = '$PD_switch_setenforce', PD_post_destination_raw = '$PD_post_destination_raw', PD_session_id = '$PD_session_id', PD_libfilename = '$PD_libfilename', PD_latest_version_known = '$PD_latest_version_known', PD_disable_pogo_freeze_detection = '$PD_disable_pogo_freeze_detection', RGC_auth_username = '$RGC_auth_username', RGC_auth_password = '$RGC_auth_password', RGC_websocket_uri = '$RGC_websocket_uri', RGC_boot_delay = '$RGC_boot_delay', RGC_mediaprojection_previously_started = '$RGC_mediaprojection_previously_started', RGC_suspended_mocking = '$RGC_suspended_mocking', RGC_reset_agps_once = '$RGC_reset_agps_once', RGC_overwrite_fused = '$RGC_overwrite_fused', RGC_switch_enable_auth_header = '$RGC_switch_enable_auth_header', RGC_reset_agps_continuously = '$RGC_reset_agps_continuously', RGC_reset_google_play_services = '$RGC_reset_google_play_services', RGC_last_location_longitude = '$RGC_last_location_longitude', RGC_last_location_altitude = '$RGC_last_location_altitude', RGC_last_location_latitude = '$RGC_last_location_latitude', RGC_boot_startup = '$RGC_boot_startup', RGC_use_mock_location = '$RGC_use_mock_location', RGC_oom_adj_override = '$RGC_oom_adj_override',  RGC_location_reporter_service_running = '$RGC_location_reporter_service_running', RGC_stop_location_provider_service = '$RGC_stop_location_provider_service', RGC_autostart_services = '$RGC_autostart_services'  WHERE origin = '$origin' and date = curdate();"
+        fi
+        done < <(query "select origin FROM ATVdetails where date = curdate();")
+fi
+
+
+## update db for instance 5
+if [ -z "$MAD_path_5" ]; then
+        echo ""
+        echo "No 5th instance defined"
+else
+        echo "Starting jobs for instance 5"
+        echo ""
+        cp $PATH_TO_STATS/default_files/ATVdetails.json $MAD_path_5/personal_commands/
+        curl -u $MADmin_username_5:$MADmin_password_5 "$MAD_url_5/delete_log"
+        curl -u $MADmin_username_5:$MADmin_password_5 "$MAD_url_5/reload_jobs"
+        curl -u $MADmin_username_5:$MADmin_password_5 "$MAD_url_5/install_file_all_devices?jobname=ATVdetails&type=jobType.CHAIN"
+        echo ""
+        echo "Wait timer started"
+        sleep $job_wait
+        echo ""
+        echo "Start processing jobs instance 5"
+        mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "insert ignore into ATVdetails (date,origin) select curdate(), name from $MAD_DB.settings_device;"
+
+        query(){
+        mysql -u$SQL_user -p$SQL_password -NB -h$DB_IP -P$DB_PORT $STATS_DB -e "$1;"
+        }
+        while read -r origin _ ;do
+        arch=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=ARCH=).*?(?= )')
+        rgc=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC=).*?(?= )')
+        pogodroid=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD=).*?(?= )')
+        pogo=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PoGo=).*?(?= )')
+        rom=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=ROM=).*?(?= )')
+        pogo_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PoGo_Autoupdate=).*?(?= )')
+        rgc_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_Autoupdate=).*?(?= )')
+        pd_update=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_Autoupdate=).*?(?= )')
+        pingreboot=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=Pingreboot=).*?(?= )')
+        temperature=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=Temperature=).*?(?= )')
+        Magisk=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=Magisk=).*?(?= )')
+        Modules=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=Modules=).*?(?= Gmail)')
+        IP=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=IP=).*?(?= )')
+        Gmail=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=Gmail=).*?(?= )')
+        PD_auth_username=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_auth_username=).*?(?= )')
+        PD_auth_password=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_auth_password=).*?(?= )')
+        PD_user_login=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_user_id=).*?(?= )')
+        PD_auth_id=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_auth_id=).*?(?= )')
+        PD_auth_token=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_auth_token=).*?(?= )')
+        PD_post_destination=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_post_destination=).*?(?= )' | sed 's/, //')
+        PD_boot_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_boot_delay=).*?(?= )')
+        PD_injection_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_preference_inject_after_seconds=).*?(?= )')
+        PD_switch_disable_last_sent=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_switch_disable_last_sent=).*?(?= )')
+        PD_intentional_stop=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_intentional_stop=).*?(?= )')
+        PD_switch_send_protos=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_switch_send_protos=).*?(?= )')
+        PD_last_time_injected=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_last_time_injected=).*?(?= )')
+        PD_switch_disable_external_communication=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_switch_disable_external_communication=).*?(?= )')
+        PD_last_pid_injected=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_last_pid_injected=).*?(?= )')
+        PD_switch_enable_oomadj=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_switch_enable_oomadj=).*?(?= )')
+        PD_switch_enable_auth_header=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_switch_enable_auth_header=).*?(?= )')
+        PD_switch_send_raw_protos=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_switch_send_raw_protos=).*?(?= )')
+        PD_switch_popup_last_sent=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_switch_popup_last_sent=).*?(?= )')
+        PD_full_daemon=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_full_daemon=).*?(?= )')
+        PD_disable_pogo_freeze_detection=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_disable_pogo_freeze_detection=).*?(?= )')
+        PD_switch_enable_mock_location_patch=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_switch_enable_mock_location_patch=).*?(?= )')
+        PD_last_system_patch_timestamp=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_last_system_patch_timestamp=).*?(?= )')
+        PD_last_sys_inj=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_last_sys_inj=).*?(?= )')
+        PD_default_mappging_mode=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_default_mappging_mode=).*?(?= )')
+        PD_switch_setenforce=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_switch_setenforce=).*?(?= )')
+        PD_post_destination_raw=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_post_destination_raw=).*?(?= )')
+        PD_session_id=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_session_id=).*?(?= )')
+        PD_libfilename=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_libfilename=).*?(?= )')
+        PD_latest_version_known=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=PD_latest_version_known=).*?(?= )')
+        RGC_auth_username=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_auth_username=).*?(?= )')
+        RGC_auth_password=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_auth_password=).*?(?= )')
+        RGC_websocket_uri=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_websocket_uri=).*?(?= )')
+        RGC_boot_delay=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_boot_delay=).*?(?= )')
+        RGC_mediaprojection_previously_started=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_mediaprojection_previously_started=).*?(?= )')
+        RGC_suspended_mocking=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_suspended_mocking=).*?(?= )')
+        RGC_reset_agps_once=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_reset_agps_once=).*?(?= )')
+        RGC_overwrite_fused=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_overwrite_fused=).*?(?= )')
+        RGC_switch_enable_auth_header=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_switch_enable_auth_header=).*?(?= )')
+        RGC_reset_agps_continuously=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_reset_agps_continuously=).*?(?= )')
+        RGC_reset_google_play_services=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_reset_google_play_services=).*?(?= )')
+        RGC_last_location_longitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_last_location_longitude=).*?(?= )')
+        RGC_last_location_altitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_last_location_altitude=).*?(?= )')
+        RGC_last_location_latitude=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_last_location_latitude=).*?(?= )')
+        RGC_boot_startup=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_boot_startup=).*?(?= )')
+        RGC_use_mock_location=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_use_mock_location=).*?(?= )')
+        RGC_oom_adj_override=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_oom_adj_override=).*?(?= )')
+        RGC_location_reporter_service_running=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_location_reporter_service_running=).*?(?= )')
+        RGC_stop_location_provider_service=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_stop_location_provider_service=).*?(?= )')
+        RGC_autostart_services=$(grep -w RGC_websocket_origin=$origin $MAD_path_5/update_log.json| grep -o -P '(?<=RGC_autostart_services=).*?(?= )')
+
+        if [ "$rgc" != '' ]; then
+                mysql $STATS_DB -u$SQL_user -p$SQL_password -h$DB_IP -P$DB_PORT -N -e "UPDATE ATVdetails set arch = '$arch', rgc = '$rgc', pogodroid = '$pogodroid', pogo = '$pogo', rom = '$rom', magisk = '$Magisk', pogo_update = '$pogo_update', rgc_update = '$rgc_update', pd_update = '$pd_update', pingreboot = '$pingreboot', temperature = '$temperature', magisk_modules = '$Modules', ip = '$IP', gmail = '$Gmail', PD_auth_username = '$PD_auth_username', PD_auth_password = '$PD_auth_password', PD_user_login = '$PD_user_login', PD_auth_id = '$PD_auth_id', PD_auth_token = '$PD_auth_token', PD_post_destination = '$PD_post_destination', PD_boot_delay = '$PD_boot_delay', PD_injection_delay = '$PD_injection_delay', PD_switch_disable_last_sent = '$PD_switch_disable_last_sent', PD_intentional_stop = '$PD_intentional_stop', PD_switch_send_protos = '$PD_switch_send_protos', PD_last_time_injected = '$PD_last_time_injected', PD_switch_disable_external_communication = '$PD_switch_disable_external_communication', PD_last_pid_injected = '$PD_last_pid_injected', PD_switch_enable_oomadj = '$PD_switch_enable_oomadj', PD_switch_enable_auth_header = '$PD_switch_enable_auth_header', PD_switch_send_raw_protos = '$PD_switch_send_raw_protos', PD_switch_popup_last_sent = '$PD_switch_popup_last_sent', PD_full_daemon = '$PD_full_daemon', PD_switch_enable_mock_location_patch = '$PD_switch_enable_mock_location_patch', PD_last_system_patch_timestamp = '$PD_last_system_patch_timestamp', PD_last_sys_inj = '$PD_last_sys_inj', PD_default_mappging_mode = '$PD_default_mappging_mode', PD_switch_setenforce = '$PD_switch_setenforce', PD_post_destination_raw = '$PD_post_destination_raw', PD_session_id = '$PD_session_id', PD_libfilename = '$PD_libfilename', PD_latest_version_known = '$PD_latest_version_known', PD_disable_pogo_freeze_detection = '$PD_disable_pogo_freeze_detection', RGC_auth_username = '$RGC_auth_username', RGC_auth_password = '$RGC_auth_password', RGC_websocket_uri = '$RGC_websocket_uri', RGC_boot_delay = '$RGC_boot_delay', RGC_mediaprojection_previously_started = '$RGC_mediaprojection_previously_started', RGC_suspended_mocking = '$RGC_suspended_mocking', RGC_reset_agps_once = '$RGC_reset_agps_once', RGC_overwrite_fused = '$RGC_overwrite_fused', RGC_switch_enable_auth_header = '$RGC_switch_enable_auth_header', RGC_reset_agps_continuously = '$RGC_reset_agps_continuously', RGC_reset_google_play_services = '$RGC_reset_google_play_services', RGC_last_location_longitude = '$RGC_last_location_longitude', RGC_last_location_altitude = '$RGC_last_location_altitude', RGC_last_location_latitude = '$RGC_last_location_latitude', RGC_boot_startup = '$RGC_boot_startup', RGC_use_mock_location = '$RGC_use_mock_location', RGC_oom_adj_override = '$RGC_oom_adj_override',  RGC_location_reporter_service_running = '$RGC_location_reporter_service_running', RGC_stop_location_provider_service = '$RGC_stop_location_provider_service', RGC_autostart_services = '$RGC_autostart_services'  WHERE origin = '$origin' and date = curdate();"
+        fi
+        done < <(query "select origin FROM ATVdetails where date = curdate();")
+fi

--- a/cron_files/quest_recalc.sh
+++ b/cron_files/quest_recalc.sh
@@ -6,7 +6,7 @@ source $folder/config.ini
 ## recalculate Quest routes for instance 1
 if [ -z "$MAD_instance_name_1" ]; then
         echo ""
-	echo "No instance defined"
+	echo "No MAD instance defined"
 else
         echo ""
 	echo "Start recalculation Quest routes for instance 1"
@@ -26,7 +26,7 @@ fi
 ## recalculate Quest routes for instance 2
 if [ -z "$MAD_instance_name_2" ]; then
         echo ""
-        echo "No 2nd instance defined"
+        echo "No 2nd MAD instance defined"
 else
         echo ""
         echo "Start recalculation Quest routes for instance 2"
@@ -41,4 +41,64 @@ else
         echo ""
         sleep $quest_recalc_wait
 	done < <(query "select a.area_id from settings_area_pokestops a, settings_area b, madmin_instance c where a.area_id = b.area_id and b.instance_id = c.instance_id and a.route_calc_algorithm = 'route' and c.name = '$MAD_instance_name_2';")
+fi
+
+## recalculate Quest routes for instance 3
+if [ -z "$MAD_instance_name_3" ]; then
+        echo ""
+        echo "No 3rd MAD instance defined"
+else
+        echo ""
+        echo "Start recalculation Quest routes for instance 3"
+
+        query(){
+        mysql  -u$DB_user -p$DB_pass -NB -h$DB_IP -P$DB_PORT $MAD_db -e "$1;"
+        }
+        while read -r area_id _ ;do
+        echo Recalculating area_id: $area_id
+        curl -s -u $MADmin_username_3:$MADmin_password_3 -H 'Content-Type: application/json-rpc' -d '{"call": "recalculate"}' $MAD_url_3/api/area/$area_id
+        echo Sleeping $quest_recalc_wait
+        echo ""
+        sleep $quest_recalc_wait
+        done < <(query "select a.area_id from settings_area_pokestops a, settings_area b, madmin_instance c where a.area_id = b.area_id and b.instance_id = c.instance_id and a.route_calc_algorithm = 'route' and c.name = '$MAD_instance_name_3';")
+fi
+
+## recalculate Quest routes for instance 4
+if [ -z "$MAD_instance_name_4" ]; then
+        echo ""
+        echo "No 4th MAD instance defined"
+else
+        echo ""
+        echo "Start recalculation Quest routes for instance 4"
+
+        query(){
+        mysql  -u$DB_user -p$DB_pass -NB -h$DB_IP -P$DB_PORT $MAD_db -e "$1;"
+        }
+        while read -r area_id _ ;do
+        echo Recalculating area_id: $area_id
+        curl -s -u $MADmin_username_4:$MADmin_password_4 -H 'Content-Type: application/json-rpc' -d '{"call": "recalculate"}' $MAD_url_4/api/area/$area_id
+        echo Sleeping $quest_recalc_wait
+        echo ""
+        sleep $quest_recalc_wait
+        done < <(query "select a.area_id from settings_area_pokestops a, settings_area b, madmin_instance c where a.area_id = b.area_id and b.instance_id = c.instance_id and a.route_calc_algorithm = 'route' and c.name = '$MAD_instance_name_4';")
+fi
+
+## recalculate Quest routes for instance 5
+if [ -z "$MAD_instance_name_5" ]; then
+        echo ""
+        echo "No 5th MAD instance defined"
+else
+        echo ""
+        echo "Start recalculation Quest routes for instance 5"
+
+        query(){
+        mysql  -u$DB_user -p$DB_pass -NB -h$DB_IP -P$DB_PORT $MAD_db -e "$1;"
+        }
+        while read -r area_id _ ;do
+        echo Recalculating area_id: $area_id
+        curl -s -u $MADmin_username_5:$MADmin_password_5 -H 'Content-Type: application/json-rpc' -d '{"call": "recalculate"}' $MAD_url_5/api/area/$area_id
+        echo Sleeping $quest_recalc_wait
+        echo ""
+        sleep $quest_recalc_wait
+        done < <(query "select a.area_id from settings_area_pokestops a, settings_area b, madmin_instance c where a.area_id = b.area_id and b.instance_id = c.instance_id and a.route_calc_algorithm = 'route' and c.name = '$MAD_instance_name_5';")
 fi

--- a/default_files/02_stats_network_area.json.default
+++ b/default_files/02_stats_network_area.json.default
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1605738744567,
+  "iteration": 1607366751089,
   "links": [],
   "panels": [
     {
@@ -108,7 +108,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroup(Datetime,$__interval) as 'time',\n  sum(Mons_all) AS \"Mons_all\",\n  sum(MonsIV) AS \"MonsIV\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroup(Datetime,$__interval) as 'time',\n  sum(Mons_all) AS \"Mons_all\",\n  sum(MonsIV) AS \"MonsIV\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -168,7 +168,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  100*sum(MonsIV)/sum(Mons_all) AS '% IV'\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  100*sum(MonsIV)/sum(Mons_all) AS '% IV'\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "B",
           "select": [
             [
@@ -285,7 +285,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  100*sum(a.TRPL)/sum(a.RPL) AS \"% Uptime\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(datetime) and\n  a.RPL = '$RPL' and\n  a.Worker = b.Origin and\n  b.Area in ($Area)\nGROUP BY 1\nORDER BY $__timeGroup(a.Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  100*sum(a.TRPL)/sum(a.RPL) AS \"% Uptime\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(datetime) and\n  a.RPL = '$RPL' and\n  a.Worker = b.Origin and\n  substring_index(b.Area,'_',1) in ($Area)\nGROUP BY 1\nORDER BY $__timeGroup(a.Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -402,7 +402,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Reb) AS \"Reboots\",\n  sum(a.Res) AS \"Restarts\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(a.datetime) and\n  a.RPL = '$RPL' and\n  a.Worker = b.Origin and\n  b.Area in ($Area)\nGROUP BY 1\nORDER BY $__timeGroup(a.Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Reb) AS \"Reboots\",\n  sum(a.Res) AS \"Restarts\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(a.datetime) and\n  a.RPL = '$RPL' and\n  a.Worker = b.Origin and\n  substring_index(b.Area,'_',1) in ($Area)\nGROUP BY 1\nORDER BY $__timeGroup(a.Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -519,7 +519,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Quest) AS \"Quest\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(a.datetime) and\n  a.RPL = '$RPL' and\n  a.Worker = b.Origin and\n  b.Area in ($Area)\nGROUP BY 1\nORDER BY $__timeGroup(a.Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Quest) AS \"Quest\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(a.datetime) and\n  a.RPL = '$RPL' and\n  a.Worker = b.Origin and\n  substring_index(b.Area,'_',1) in ($Area)\nGROUP BY 1\nORDER BY $__timeGroup(a.Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -649,7 +649,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(DBspawns) AS \"DBspawns\",\n  sum(Last_scanned_today_acc) AS \"Scanned today\",\n  sum(Spawn_add) AS \"Spawns added\",\n  sum(Spawn_NULL) AS \"Spawns unknown\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(DBspawns) AS \"DBspawns\",\n  sum(Last_scanned_today_acc) AS \"Scanned today\",\n  sum(Spawn_add) AS \"Spawns added\",\n  sum(Spawn_NULL) AS \"Spawns unknown\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -766,7 +766,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(Last_scanned_1d) AS \"Last scanned yesterday\",\n  sum(Last_scanned_2d) AS \"Last scanned 2d ago\",\n  sum(Last_scanned_3d) AS \"Last scanned 3d ago\",\n  sum(Last_scanned_7dp) AS \"Last scanned >7d ago\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(Last_scanned_1d) AS \"Last scanned yesterday\",\n  sum(Last_scanned_2d) AS \"Last scanned 2d ago\",\n  sum(Last_scanned_3d) AS \"Last scanned 3d ago\",\n  sum(Last_scanned_7dp) AS \"Last scanned >7d ago\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -888,7 +888,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(Spawndef15) AS \"60m spawn\",\n  sum(SpawndefNot15) AS \"30m spawn\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(Spawndef15) AS \"60m spawn\",\n  sum(SpawndefNot15) AS \"30m spawn\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -1012,7 +1012,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  100*sum(w5)/sum(Mons_all) AS '% scanned within 5m',\n  100*sum(w10)/sum(Mons_all) AS '% scanned within 10m',\n  100*sum(w15)/sum(Mons_all) AS '% scanned within 15m',\n  100*sum(w20)/sum(Mons_all) AS '% scanned within 20m'\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  100*sum(w5)/sum(Mons_all) AS '% scanned within 5m',\n  100*sum(w10)/sum(Mons_all) AS '% scanned within 10m',\n  100*sum(w15)/sum(Mons_all) AS '% scanned within 15m',\n  100*sum(w20)/sum(Mons_all) AS '% scanned within 20m'\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = '$RPL' and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY 1\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -1209,7 +1209,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Tloc) AS \"#Locations handled\",\n  sum(a.Tp) AS \"#Teleports\",\n  sum(a.Wk) AS \"#Walk\"\nFROM stats_worker a, Area b\nWHERE\n  a.RPL = '$RPL' and\n  a.Worker = b.Origin and\n  b.Area in ($Area)\nGROUP BY 1\nORDER BY $__timeGroup(a.Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Tloc) AS \"#Locations handled\",\n  sum(a.Tp) AS \"#Teleports\",\n  sum(a.Wk) AS \"#Walk\"\nFROM stats_worker a, Area b\nWHERE\n  a.RPL = '$RPL' and\n  a.Worker = b.Origin and\n  substring_index(b.Area,'_',1) in ($Area)\nGROUP BY 1\nORDER BY $__timeGroup(a.Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -1326,7 +1326,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  100*sum(a.LocOk)/sum(a.Tloc) AS \"Location Success Rate\",\n  100*sum(a.TpOk)/sum(a.Tp) AS \"Teleport Success Rate\",\n  100*sum(a.WkOk)/sum(a.Wk) AS \"Walk Success Rate\"\nFROM stats_worker a, Area b\nWHERE\n  a.RPL = '$RPL' and\n  a.Worker = b.Origin and\n  b.Area in ($Area)\nGROUP BY 1\nORDER BY $__timeGroup(a.Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  100*sum(a.LocOk)/sum(a.Tloc) AS \"Location Success Rate\",\n  100*sum(a.TpOk)/sum(a.Tp) AS \"Teleport Success Rate\",\n  100*sum(a.WkOk)/sum(a.Wk) AS \"Walk Success Rate\"\nFROM stats_worker a, Area b\nWHERE\n  a.RPL = '$RPL' and\n  a.Worker = b.Origin and\n  substring_index(b.Area,'_',1) in ($Area)\nGROUP BY 1\nORDER BY $__timeGroup(a.Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -1425,7 +1425,7 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_POGODB}",
-        "definition": "select Area from stats_area;",
+        "definition": "select substring_index(Area,'_',1) from stats_area;",
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -1433,7 +1433,7 @@
         "multi": false,
         "name": "Area",
         "options": [],
-        "query": "select Area from stats_area;",
+        "query": "select substring_index(Area,'_',1) from stats_area;",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1490,5 +1490,5 @@
   "timezone": "",
   "title": "02. Stats network/area level",
   "uid": "KY-d_hOMz",
-  "version": 34
+  "version": 36
 }

--- a/default_files/03_stats_network_area_ex.json.default
+++ b/default_files/03_stats_network_area_ex.json.default
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1605738307817,
+  "iteration": 1607366848708,
   "links": [],
   "panels": [
     {
@@ -108,7 +108,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroup(Datetime,$__interval) AS \"time\",\n  sum(Mons_all) AS \"Mons_all\",\n  sum(MonsIV) AS \"MonsIV\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroup(Datetime,$__interval) AS \"time\",\n  sum(Mons_all) AS \"Mons_all\",\n  sum(MonsIV) AS \"MonsIV\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -168,7 +168,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  100*sum(MonsIV)/sum(Mons_all) AS '% IV'\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  100*sum(MonsIV)/sum(Mons_all) AS '% IV'\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "B",
           "select": [
             [
@@ -285,7 +285,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  100*sum(a.TRPL)/sum(a.RPL) AS \"% Uptime\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(a.datetime) and\n  RPL = 60 and\n  a.worker = b.Origin  and\n  time(Datetime) not in ($Hours_excluded) and\n  b.Area in ($Area)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(a.Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  100*sum(a.TRPL)/sum(a.RPL) AS \"% Uptime\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(a.datetime) and\n  RPL = 60 and\n  a.worker = b.Origin  and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(b.Area,'_',1) in ($Area)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(a.Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -402,7 +402,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Reb) AS \"Reboots\",\n  sum(a.Res) AS \"Restarts\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(a.datetime) and\n  RPL = 60 and\n  a.worker = b.Origin  and\n  time(Datetime) not in ($Hours_excluded) and\n  b.Area in ($Area)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(a.Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Reb) AS \"Reboots\",\n  sum(a.Res) AS \"Restarts\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(a.datetime) and\n  RPL = 60 and\n  a.worker = b.Origin  and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(b.Area,'_',1) in ($Area)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(a.Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -519,7 +519,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Quest) AS \"Quest\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(a.datetime) and\n  RPL = 60 and\n  a.worker = b.Origin  and\n  time(Datetime) not in ($Hours_excluded) and\n  b.Area in ($Area)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(a.Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Quest) AS \"Quest\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(a.datetime) and\n  RPL = 60 and\n  a.worker = b.Origin  and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(b.Area,'_',1) in ($Area)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(a.Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -649,7 +649,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(DBspawns) AS \"DBspawns\",\n  sum(Last_scanned_today_acc) AS \"Scanned today\",\n  sum(Spawn_add) AS \"Spawns added\",\n  sum(Spawn_NULL) AS \"Spawns unknown\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(DBspawns) AS \"DBspawns\",\n  sum(Last_scanned_today_acc) AS \"Scanned today\",\n  sum(Spawn_add) AS \"Spawns added\",\n  sum(Spawn_NULL) AS \"Spawns unknown\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -766,7 +766,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(Last_scanned_1d) AS \"Last scanned yesterday\",\n  sum(Last_scanned_2d) AS \"Last scanned 2d ago\",\n  sum(Last_scanned_3d) AS \"Last scanned 3d ago\",\n  sum(Last_scanned_7dp) AS \"Last scanned >7d ago\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(Last_scanned_1d) AS \"Last scanned yesterday\",\n  sum(Last_scanned_2d) AS \"Last scanned 2d ago\",\n  sum(Last_scanned_3d) AS \"Last scanned 3d ago\",\n  sum(Last_scanned_7dp) AS \"Last scanned >7d ago\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -888,7 +888,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(Spawndef15) AS \"60m spawn\",\n  sum(SpawndefNot15) AS \"30m spawn\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  sum(Spawndef15) AS \"60m spawn\",\n  sum(SpawndefNot15) AS \"30m spawn\"\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -1012,7 +1012,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  100*sum(w5)/sum(Mons_all) AS '% scanned within 5m',\n  100*sum(w10)/sum(Mons_all) AS '% scanned within 10m',\n  100*sum(w15)/sum(Mons_all) AS '% scanned within 15m',\n  100*sum(w20)/sum(Mons_all) AS '% scanned within 20m'\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  Area in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(Datetime,$__interval),\n  100*sum(w5)/sum(Mons_all) AS '% scanned within 5m',\n  100*sum(w10)/sum(Mons_all) AS '% scanned within 10m',\n  100*sum(w15)/sum(Mons_all) AS '% scanned within 15m',\n  100*sum(w20)/sum(Mons_all) AS '% scanned within 20m'\nFROM stats_area\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(Area,'_',1) in ($Area) and\n  Fence in ($Fence)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -1209,7 +1209,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Tloc) AS \"#Locations handled\",\n  sum(a.Tp) AS \"#Teleports\",\n  sum(a.Wk) AS \"#Walk\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  a.worker = b.Origin  and\n  time(Datetime) not in ($Hours_excluded) and\n  b.Area in ($Area)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(a.Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  sum(a.Tloc) AS \"#Locations handled\",\n  sum(a.Tp) AS \"#Teleports\",\n  sum(a.Wk) AS \"#Walk\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  a.worker = b.Origin  and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(b.Area,'_',1) in ($Area)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(a.Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -1326,7 +1326,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  100*sum(a.LocOk)/sum(a.Tloc) AS \"Location Success Rate\",\n  100*sum(a.TpOk)/sum(a.Tp) AS \"Teleport Success Rate\",\n  100*sum(a.WkOk)/sum(a.Wk) AS \"Walk Success Rate\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  a.worker = b.Origin  and\n  time(Datetime) not in ($Hours_excluded) and\n  b.Area in ($Area)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(a.Datetime,$__interval)",
+          "rawSql": "SELECT\n  $__timeGroupAlias(a.Datetime,$__interval),\n  100*sum(a.LocOk)/sum(a.Tloc) AS \"Location Success Rate\",\n  100*sum(a.TpOk)/sum(a.Tp) AS \"Teleport Success Rate\",\n  100*sum(a.WkOk)/sum(a.Wk) AS \"Walk Success Rate\"\nFROM stats_worker a, Area b\nWHERE\n  $__timeFilter(datetime) and\n  RPL = 60 and\n  a.worker = b.Origin  and\n  time(Datetime) not in ($Hours_excluded) and\n  substring_index(b.Area,'_',1) in ($Area)\nGROUP BY date(Datetime)\nORDER BY $__timeGroup(a.Datetime,$__interval)",
           "refId": "A",
           "select": [
             [
@@ -1402,7 +1402,7 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_POGODB}",
-        "definition": "select Area from stats_area;",
+        "definition": "select substring_index(Area,'_',1) from stats_area;",
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -1410,7 +1410,7 @@
         "multi": false,
         "name": "Area",
         "options": [],
-        "query": "select Area from stats_area;",
+        "query": "select substring_index(Area,'_',1) from stats_area;",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1490,5 +1490,5 @@
   "timezone": "",
   "title": "03. Stats network/area level exclude hours",
   "uid": "KY-d_hOMb",
-  "version": 23
+  "version": 24
 }

--- a/default_files/30_mon_stuff.json.default
+++ b/default_files/30_mon_stuff.json.default
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.2.2"
+      "version": "7.3.1"
     },
     {
       "type": "panel",
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1604258975474,
+  "iteration": 1607366897017,
   "links": [],
   "panels": [
     {
@@ -87,7 +87,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.3.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -207,7 +207,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.3.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -331,7 +331,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.3.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -455,7 +455,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.3.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -549,6 +549,7 @@
         "current": {},
         "datasource": "${DS_POGODB}",
         "definition": "select RPL from stats_area;",
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -570,14 +571,15 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_POGODB}",
-        "definition": "select Area from stats_area;",
+        "definition": "select substring_index(Area,'_',1) from stats_area;",
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": false,
         "name": "Area",
         "options": [],
-        "query": "select Area from stats_area;",
+        "query": "select substring_index(Area,'_',1) from stats_area;",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -598,5 +600,5 @@
   "timezone": "",
   "title": "30. Mon stuff",
   "uid": "MXNPeYtMz",
-  "version": 10
+  "version": 12
 }

--- a/default_files/ATVdetails.json
+++ b/default_files/ATVdetails.json
@@ -1,0 +1,9 @@
+{
+  "ATVdetails": [
+    {
+      "TYPE": "jobType.PASSTHROUGH",
+      "SYNTAX": "echo \" ARCH=$(uname -m) ROM=$(cat /sdcard/madversion 2>/dev/null || echo unknown) RGC=$(dumpsys package de.grennith.rgc.remotegpscontroller | grep versionName | head -n1 | sed 's/ *versionName=//') PD=$(dumpsys package com.mad.pogodroid | grep versionName | head -n1 | sed 's/ *versionName=//') PoGo=$(dumpsys package com.nianticlabs.pokemongo | grep versionName | head -n1 | sed 's/ *versionName=//') PoGo_Autoupdate=$([ -f /sdcard/disableautopogoupdate ] && echo disabled || echo enabled) PD_Autoupdate=$([ -f /sdcard/disableautopogodroidupdate ] && echo disabled || echo enabled) RGC_Autoupdate=$([ -f /sdcard/disableautorgcupdate ] && echo disabled || echo enabled) Pingreboot=$([ -f /sdcard/pingreboot ] && echo enabled || echo disabled) Temperature=$(cat sys/class/thermal/thermal_zone0/temp | awk '{print substr($0,1,length()-3)}') Magisk=$(magisk -c | sed 's/:.*//') Modules=$(ls -1 /sbin/.magisk/img 2>/dev/null) Gmail=$(grep 'com.android.contacts\"' /data/system/sync/accounts.xml | cut -d'\"' -f8) IP=$(ifconfig wlan0 |grep 'inet addr' |cut -d ':' -f2 |cut -d ' ' -f1 && ifconfig eth0 |grep 'inet addr' |cut -d ':' -f2 |cut -d ' ' -f1) \" && awk -F'[\"]+' '/value/{print \"PD_\"$2 \"=\" $4}' /data/data/com.mad.pogodroid/shared_prefs/com.mad.pogodroid_preferences.xml |tr '\n' ' ' && awk -F'[<>\"]+' '/string/{print \"PD_\"$3 \"=\" $4}' /data/data/com.mad.pogodroid/shared_prefs/com.mad.pogodroid_preferences.xml |tr '\n' ' ' && awk -F'[\"]+' '/value/{print \"RGC_\"$2 \"=\" $4}' /data/data/de.grennith.rgc.remotegpscontroller/shared_prefs/de.grennith.rgc.remotegpscontroller_preferences.xml |tr '\n' ' ' && awk -F'[<>\"]+' '/string/{print \"RGC_\"$3 \"=\" $4}' /data/data/de.grennith.rgc.remotegpscontroller/shared_prefs/de.grennith.rgc.remotegpscontroller_preferences.xml |tr '\n' ' ' && print ' '",
+      "FIELDNAME": "Versions"
+    }
+  ]
+}

--- a/default_files/config.ini.example
+++ b/default_files/config.ini.example
@@ -6,7 +6,7 @@ DB_PORT=3306
 MAD_DB=rmdb
 STATS_DB=pogodb
 
-## MADmin settings, for quest recalc ##
+## MADmin settings, for quest recalc and getting ATV settings##
 # MAD instance 1
 MAD_instance_name_1=MAD
 MAD_url_1=http://localhost:5000
@@ -19,6 +19,24 @@ MAD_url_2=
 MADmin_username_2=
 MADmin_password_2=
 
+# MAD instance 3, must be connected to same DB as instance 1
+MAD_instance_name_3=
+MAD_url_3=
+MADmin_username_3=
+MADmin_password_3=
+
+# MAD instance 4, must be connected to same DB as instance 1
+MAD_instance_name_4=
+MAD_url_4=
+MADmin_username_4=
+MADmin_password_4=
+
+# MAD instance 5, must be connected to same DB as instance 1
+MAD_instance_name_5=
+MAD_url_5=
+MADmin_username_5=
+MADmin_password_5=
+
 ## Stats ##
 PATH_TO_STATS=/home/dkmur/temp/Stats/
 DEFINED_SCAN_AREAS='Amsterdam, London, Paris'		# only used for visualisation in Stats menu, not used for Grafana
@@ -28,6 +46,10 @@ DEFAULT_AREA=London					# Default area to be used for Stats sql queries, not use
 FENCE=box						# options:MAD/box/world. MAD=use MAD (sub)fences, box=define lat/lon max/min per area yourself, world=like box but Stats will create one big fence covering everything
 MAD_DEVICE_INSERT=false					# auto fill table Area, linking devices to Areas(geofence name of mon_mitm), requires FENCE=MAD. Note: only works if each walker contain max 1 mon_mitm area.  
 MAD_FENCE_UPDATE_INTERVAL=hour				# hour or day, interval for updating Stats on MAD geofences, requires FENCE=MAD. New devices will be added at same interval in case MAD_DEVICE_INSERT=true.
+
+## ATV details ##
+atvdetails=true						# true/false: get cpu temperature, sw versions and RGC/PD settings from atv 
+job_wait=2m							# wait time for jobs to finish i.e. 2m or 300s
 
 ## Grafana ##
 DataSource_stats=pogodb

--- a/default_files/config.ini.example
+++ b/default_files/config.ini.example
@@ -12,30 +12,35 @@ MAD_instance_name_1=MAD
 MAD_url_1=http://localhost:5000
 MADmin_username_1=someuser
 MADmin_password_1=somepass
+MAD_path_1=/home/me/MAD/
 
 # MAD instance 2, must be connected to same DB as instance 1
 MAD_instance_name_2=
 MAD_url_2=
 MADmin_username_2=
 MADmin_password_2=
+MAD_path_2=
 
 # MAD instance 3, must be connected to same DB as instance 1
 MAD_instance_name_3=
 MAD_url_3=
 MADmin_username_3=
 MADmin_password_3=
+MAD_path_3=
 
 # MAD instance 4, must be connected to same DB as instance 1
 MAD_instance_name_4=
 MAD_url_4=
 MADmin_username_4=
 MADmin_password_4=
+MAD_path_4=
 
 # MAD instance 5, must be connected to same DB as instance 1
 MAD_instance_name_5=
 MAD_url_5=
 MADmin_username_5=
 MADmin_password_5=
+MAD_path_5=
 
 ## Stats ##
 PATH_TO_STATS=/home/dkmur/temp/Stats/

--- a/default_files/config.ini.example
+++ b/default_files/config.ini.example
@@ -54,7 +54,7 @@ MAD_FENCE_UPDATE_INTERVAL=hour				# hour or day, interval for updating Stats on 
 
 ## ATV details ##
 atvdetails=true						# true/false: get cpu temperature, sw versions and RGC/PD settings from atv 
-job_wait=2m							# wait time for jobs to finish i.e. 2m or 300s
+job_wait=2m						# wait time for jobs to finish i.e. 2m or 300s
 
 ## Grafana ##
 DataSource_stats=pogodb

--- a/default_files/tables.sql.default
+++ b/default_files/tables.sql.default
@@ -160,6 +160,37 @@ CREATE TABLE IF NOT EXISTS `pokemon_history_temp` (
   KEY `pokemon_history_temp_last_modified` (`last_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE `ATVdetails` (
+  `date` date COLLATE utf8mb4_unicode_ci NOT NULL,
+  `origin` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `rom` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `rgc` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pogodroid` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pogo` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pogo_update` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pd_update` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `rgc_update` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pingreboot` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `temperature` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `magisk` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `magisk_modules` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `ip` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `gmail` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `PD_auth_username` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `PD_auth_password` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `PD_user_id` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `PD_auth_id` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `PD_auth_token` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `PD_post_destination` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `PD_boot_delay` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `PD_injection_delay` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `RGC_auth_username` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `RGC_auth_password` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `RGC_websocket_uri` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `RGC_boot_delay` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`date`,`origin`)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 ALTER TABLE stats_area
 ADD COLUMN IF NOT EXISTS DBspawns_event int(6) DEFAULT NULL AFTER DBspawns,
 ADD COLUMN IF NOT EXISTS w5 int(6) NOT NULL DEFAULT 0 AFTER AvgMinutesLeft,
@@ -192,3 +223,59 @@ CHANGE COLUMN `Area` `Area` varchar(50) DEFAULT 'World';
 
 ALTER TABLE `Area`
 DROP COLUMN IF EXISTS `id`;
+
+
+SET SESSION innodb_strict_mode=OFF;
+alter table ATVdetails
+add column IF NOT EXISTS `arch` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after origin,
+add column IF NOT EXISTS `pd_update` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after pogo_update,
+add column IF NOT EXISTS `rgc_update` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after pd_update,
+add column IF NOT EXISTS `pingreboot` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after rgc_update,
+add column IF NOT EXISTS `temperature` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after pingreboot,
+change column IF EXISTS `origin` origin varchar(50),
+change column IF EXISTS `eth0` ip varchar(40),
+change column IF EXISTS `magisk_modules` magisk_modules varchar(200),
+add column IF NOT EXISTS `gmail` varchar(60) COLLATE utf8mb4_unicode_ci DEFAULT NULL after ip,
+change column IF EXISTS `gmail` gmail varchar(60),
+add column IF NOT EXISTS `PD_user_login` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_auth_password,
+add column IF NOT EXISTS `PD_switch_disable_last_sent` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_injection_delay,
+add column IF NOT EXISTS `PD_intentional_stop` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_switch_disable_last_sent,
+add column IF NOT EXISTS `PD_switch_send_protos` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_intentional_stop,
+add column IF NOT EXISTS `PD_last_time_injected` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_switch_send_protos,
+add column IF NOT EXISTS `PD_switch_disable_external_communication` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_last_time_injected,
+add column IF NOT EXISTS `PD_last_pid_injected` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_switch_disable_external_communication,
+add column IF NOT EXISTS `PD_switch_enable_oomadj` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_last_pid_injected,
+add column IF NOT EXISTS `PD_switch_enable_auth_header` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_switch_enable_oomadj,
+add column IF NOT EXISTS `PD_switch_send_raw_protos` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_switch_enable_auth_header,
+add column IF NOT EXISTS `PD_switch_popup_last_sent` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_switch_send_raw_protos,
+add column IF NOT EXISTS `PD_full_daemon` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_switch_popup_last_sent,
+add column IF NOT EXISTS `PD_switch_enable_mock_location_patch` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_full_daemon,
+add column IF NOT EXISTS `PD_last_system_patch_timestamp` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_switch_enable_mock_location_patch,
+add column IF NOT EXISTS `PD_last_sys_inj` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_last_system_patch_timestamp,
+add column IF NOT EXISTS `PD_default_mappging_mode` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_last_sys_inj,
+add column IF NOT EXISTS `PD_switch_setenforce` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_default_mappging_mode,
+add column IF NOT EXISTS `PD_post_destination_raw` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_switch_setenforce,
+change column IF EXISTS `PD_post_destination_raw` PD_post_destination_raw varchar(100),
+add column IF NOT EXISTS `PD_session_id` varchar(60) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_post_destination_raw,
+change column IF EXISTS `PD_session_id` PD_session_id varchar(60),
+add column IF NOT EXISTS `PD_libfilename` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_session_id,
+add column IF NOT EXISTS `PD_latest_version_known` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_libfilename,
+add column IF NOT EXISTS `PD_disable_pogo_freeze_detection` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after PD_latest_version_known,
+add column IF NOT EXISTS `RGC_mediaprojection_previously_started` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_boot_delay,
+add column IF NOT EXISTS `RGC_suspended_mocking` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_mediaprojection_previously_started,
+add column IF NOT EXISTS `RGC_reset_agps_once` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_suspended_mocking,
+add column IF NOT EXISTS `RGC_overwrite_fused` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_reset_agps_once,
+add column IF NOT EXISTS `RGC_switch_enable_auth_header` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_overwrite_fused,
+add column IF NOT EXISTS `RGC_reset_agps_continuously` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_switch_enable_auth_header,
+add column IF NOT EXISTS `RGC_reset_google_play_services` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_reset_agps_continuously,
+add column IF NOT EXISTS `RGC_last_location_longitude` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_reset_google_play_services,
+add column IF NOT EXISTS `RGC_last_location_altitude` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_last_location_longitude,
+add column IF NOT EXISTS `RGC_last_location_latitude` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_last_location_altitude,
+add column IF NOT EXISTS `RGC_boot_startup` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_last_location_latitude,
+add column IF NOT EXISTS `RGC_use_mock_location` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_boot_startup,
+add column IF NOT EXISTS `RGC_oom_adj_override` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_use_mock_location,
+add column IF NOT EXISTS `RGC_location_reporter_service_running` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_oom_adj_override,
+add column IF NOT EXISTS `RGC_stop_location_provider_service` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_location_reporter_service_running,
+add column IF NOT EXISTS `RGC_autostart_services` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL after RGC_stop_location_provider_service,
+change column IF EXISTS `RGC_websocket_uri` RGC_websocket_uri varchar(60)
+;

--- a/default_files/tables.sql.default
+++ b/default_files/tables.sql.default
@@ -160,7 +160,7 @@ CREATE TABLE IF NOT EXISTS `pokemon_history_temp` (
   KEY `pokemon_history_temp_last_modified` (`last_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE `ATVdetails` (
+CREATE TABLE IF NOT EXISTS `ATVdetails` (
   `date` date COLLATE utf8mb4_unicode_ci NOT NULL,
   `origin` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
   `rom` varchar(40) COLLATE utf8mb4_unicode_ci DEFAULT NULL,

--- a/settings.run
+++ b/settings.run
@@ -73,6 +73,14 @@ then
   sed -i "$ a \#\# Cleaup spawnpoints" $PATH_TO_STATS/crontab.txt
   sed -i "$ a $SPAWN_CLEAN_MIN $SPAWN_CLEAN_HR * * * cd pathToStatscron_files/ && mysql userpass < spawn_cleanup.sql" $PATH_TO_STATS/crontab.txt
 fi
+# get ATV details
+if "$atvdetails"
+then
+  echo "Set daily download of ATV settings"
+  echo ""
+  sed -i "$ a \#\# ATV details" $PATH_TO_STATS/crontab.txt
+  sed -i "$ a 5 1 * * * cd pathToStatscron_files && ./atvdetails.sh" $PATH_TO_STATS/crontab.txt
+fi
 PATH_TO_STATS2=$(sed 's@/@\\/@g' <<< $PATH_TO_STATS)
 cd $PATH_TO_STATS && sed -i "s/pathToStats/$PATH_TO_STATS2/g" *.txt
 cd $PATH_TO_STATS && sed -i "s/STATS_DB/$STATS_DB/g" *.txt


### PR DESCRIPTION
Changes:
- added support for up to 5 MAD instances (connected to same db)
- integrated ATVdetails
- changed grafana templates 02, 03 and 30 to group areas before first ``_``

To update:
- git pull
- adapt config.ini
- execute settings.run
- update crontab (in case you choose to pull settings from ATVs)

Note:
- for those already using ATVdetails, make sure to disable it in cron
- old ATVdetails repo will no longer be maintained/removed
- new grouping in grafana templates allows you to have MAD-fences like Paris_north and Paris_south where now the data will be combined into Area Paris in grafana