### PR TITLE
reduce possible falling behind in MAD

### DIFF
--- a/cron_files/hourly.sh
+++ b/cron_files/hourly.sh
@@ -16,9 +16,9 @@ if "$pokemon"
 then
   if [ -z "$SQL_password" ]
   then
-  mysql -h$DB_IP -P$DB_PORT -u$SQL_user $MAD_DB -e "delete from pokemon where CONVERT_TZ(last_modified, '+00:00', @@global.time_zone) < now() - interval 1 hour;"
+  mysql -h$DB_IP -P$DB_PORT -u$SQL_user $MAD_DB -e "SET SESSION tx_isolation = 'READ-UNCOMMITTED'; CALL pokemon_cleanup();"
   else
-  mysql -h$DB_IP -P$DB_PORT -u$SQL_user -p$SQL_password $MAD_DB -e "delete from pokemon where CONVERT_TZ(last_modified, '+00:00', @@global.time_zone) < now() - interval 1 hour;"
+  mysql -h$DB_IP -P$DB_PORT -u$SQL_user -p$SQL_password $MAD_DB -e "SET SESSION tx_isolation = 'READ-UNCOMMITTED'; CALL pokemon_cleanup();"
   fi
 fi
 

--- a/default_files/1440_area.sql.default
+++ b/default_files/1440_area.sql.default
@@ -1,3 +1,4 @@
+SET SESSION tx_isolation = 'READ-UNCOMMITTED';
 -- Settings
 
 select @Start := concat(date(now() - interval 1440 minute),' ', SEC_TO_TIME((TIME_TO_SEC(time(now() - interval 1440 minute)) DIV 86400) * 86400));

--- a/default_files/15_area.sql.default
+++ b/default_files/15_area.sql.default
@@ -1,3 +1,4 @@
+SET SESSION tx_isolation = 'READ-UNCOMMITTED';
 -- Settings
 
 select @Start := concat(date(now() - interval 15 minute),' ', SEC_TO_TIME((TIME_TO_SEC(time(now() - interval 15 minute)) DIV 900) * 900));

--- a/default_files/60_area.sql.default
+++ b/default_files/60_area.sql.default
@@ -1,3 +1,4 @@
+SET SESSION tx_isolation = 'READ-UNCOMMITTED';
 -- Settings
 
 select @Start := concat(date(now() - interval 60 minute),' ', SEC_TO_TIME((TIME_TO_SEC(time(now() - interval 60 minute)) DIV 3600) * 3600));

--- a/default_files/procedures.sql.default
+++ b/default_files/procedures.sql.default
@@ -12,3 +12,18 @@ CREATE PROCEDURE pogodb.mon_history_temp_cleanup()
  END;  
 //
 DELIMITER ;
+
+DROP PROCEDURE IF EXISTS rmdb.pokemon_cleanup;
+DELIMITER //
+CREATE PROCEDURE rmdb.pokemon_cleanup()
+ BEGIN
+  DECLARE RowCount INT;
+  SET RowCount = (SELECT count(last_modified) FROM rmdb.pokemon WHERE CONVERT_TZ(last_modified, '+00:00', @@global.time_zone) < now() - interval 1 hour);
+   WHILE RowCount > 0 DO
+   DELETE FROM rmdb.pokemon WHERE CONVERT_TZ(last_modified, '+00:00', @@global.time_zone) < now() - interval 1 hour LIMIT 25000;
+   SET RowCount = RowCount - 25000;
+   SELECT SLEEP(1);
+   END WHILE;
+ END;  
+//
+DELIMITER ;

--- a/sql/atv_sw_overview.sql
+++ b/sql/atv_sw_overview.sql
@@ -2,99 +2,99 @@ use pogodb
 
 select "ATV architecture" as '';
 select
-date as 'date      ', rpad(ifnull(arch,'no_data '),8," ") as 'rom     ', count(origin) as 'devices'
+datetime as 'datetime  ', rpad(ifnull(arch,'no_data '),8," ") as 'rom     ', count(origin) as 'devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datime) = curdate() - interval XXA day
 
-group by date, arch
+group by datetime, arch
 ;
 
 select "ATV ROM" as '';
 select
-date as 'date      ', rpad(ifnull(rom,'no_data '),8," ") as 'rom     ', count(origin) as 'devices'
+datetime as 'datetime  ', rpad(ifnull(rom,'no_data '),8," ") as 'rom     ', count(origin) as 'devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, rom
+group by datetime, rom
 ;
 
 select "ATV ROM options" as '';
 select
-date as 'date      ', rpad(ifnull(pogo_update,'no_data '),11," ") as 'pogo_update', rpad(ifnull(pd_update,'no_data '),9," ") as pd_update, rpad(ifnull(rgc_update,'no_data '),10," ") as 'rgc_update', rpad(ifnull(pingreboot,'no_data '),10," ") as pinreboot, count(origin) as 'devices'
+datetime as 'datetime  ', rpad(ifnull(pogo_update,'no_data '),11," ") as 'pogo_update', rpad(ifnull(pd_update,'no_data '),9," ") as pd_update, rpad(ifnull(rgc_update,'no_data '),10," ") as 'rgc_update', rpad(ifnull(pingreboot,'no_data '),10," ") as pinreboot, count(origin) as 'devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, pogo_update, pd_update, rgc_update, pingreboot
+group by datetime, pogo_update, pd_update, rgc_update, pingreboot
 ;
 
 select "RemoteGpsController" as '';
 select
-date as 'date      ', rpad(ifnull(rgc,'no_data '),8," ") as'rgc     ', count(origin) as 'devices'
+datetime as 'datetime  ', rpad(ifnull(rgc,'no_data '),8," ") as'rgc     ', count(origin) as 'devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, rgc
+group by datetime, rgc
 ;
 
 select "PogoDroid" as '';
 select
-date as 'date      ', rpad(ifnull(pogodroid,'no_data'),8," ") as 'pogodroid', count(origin) as 'devices'
+datetime as 'datetime  ', rpad(ifnull(pogodroid,'no_data'),8," ") as 'pogodroid', count(origin) as 'devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, pogodroid
+group by datetime, pogodroid
 ;
 
 select "PokemonGo" as '';
 select
-date as 'date      ', rpad(ifnull(pogo,'no_data'),8," ") as 'pogo    ', count(origin) as 'devices'
+datetime as 'datetime  ', rpad(ifnull(pogo,'no_data'),8," ") as 'pogo    ', count(origin) as 'devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, pogo
+group by datetime, pogo
 ;
 
 select "Magisk" as '';
 select
-date as 'date      ', rpad(ifnull(magisk,'no_data'),8," ") as 'magisk  ', count(origin) as 'devices'
+datetime as 'datetime  ', rpad(ifnull(magisk,'no_data'),8," ") as 'magisk  ', count(origin) as 'devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, magisk
+group by datetime, magisk
 ;
 
 select "Magisk Modules" as '';
 select
-date as 'date      ', rpad(ifnull(magisk_modules,'no_data '),34," ") as 'magisk modules                    ', count(origin) as 'devices'
+datetime as 'datetime  ', rpad(ifnull(magisk_modules,'no_data '),34," ") as 'magisk modules                    ', count(origin) as 'devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, magisk_modules
+group by datetime, magisk_modules
 ;
 
 select "Average temperature" as '';
 select
-date as 'date      ', round(sum(temperature)/count(temperature),1) as 'temperature'
+date(datetime) as 'datetime  ', round(sum(temperature)/count(temperature),1) as 'temperature'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date
+group by datetime
 ;

--- a/sql/gmail.sql
+++ b/sql/gmail.sql
@@ -2,11 +2,11 @@ use pogodb
 
 select "Device IP (eth)" as '';
 select
-date as 'date      ', rpad(origin,13," ") as 'origin       ', ifnull(gmail,'no_data') as 'gmail'
+datetime as 'datetime  ', rpad(origin,13," ") as 'origin       ', ifnull(gmail,'no_data') as 'gmail'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
 order by origin
 ;

--- a/sql/ipadresses.sql
+++ b/sql/ipadresses.sql
@@ -2,11 +2,11 @@ use pogodb
 
 select "Device IP" as '';
 select
-date as 'date      ', rpad(origin,13," ") as 'origin       ', ifnull(ip,'no_data') as 'IP'
+datetime as 'datetime  ', rpad(origin,13," ") as 'origin       ', ifnull(ip,'no_data') as 'IP'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
 order by origin
 ;

--- a/sql/pd_id.sql
+++ b/sql/pd_id.sql
@@ -2,7 +2,7 @@ use pogodb
 
 select "Device PD ID" as '';
 select
-date as 'date      ', rpad(origin,13," ") as 'origin       ', ifnull(PD_auth_id,'no_data') as 'auth_id'
+datetime as 'datetime  ', rpad(origin,13," ") as 'origin       ', ifnull(PD_auth_id,'no_data') as 'auth_id'
 from ATVdetails
 
 where

--- a/sql/pd_id.sql
+++ b/sql/pd_id.sql
@@ -6,7 +6,7 @@ datetime as 'datetime  ', rpad(origin,13," ") as 'origin       ', ifnull(PD_auth
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
 order by origin
 ;

--- a/sql/pd_setting_overview.sql
+++ b/sql/pd_setting_overview.sql
@@ -2,32 +2,32 @@ use pogodb
 
 select "PogoDroid settings" as '';
 select
-date as 'date      ', rpad(ifnull(PD_auth_username,'no_data '),8," ") as 'username', rpad(ifnull(PD_auth_password,'no_data '),11," ") as 'password   ', rpad(ifnull(PD_user_login,'no_data '),20," ") as 'login               ' ,rpad(ifnull(PD_auth_token,'no_data '),18," ") as 'auth_token        ', rpad(ifnull(PD_post_destination,'no_data '),37," ") as 'post_destination                     ', count(origin) as '#devices'
+datetime as 'datetime  ', rpad(ifnull(PD_auth_username,'no_data '),8," ") as 'username', rpad(ifnull(PD_auth_password,'no_data '),11," ") as 'password   ', rpad(ifnull(PD_user_login,'no_data '),20," ") as 'login               ' ,rpad(ifnull(PD_auth_token,'no_data '),18," ") as 'auth_token        ', rpad(ifnull(PD_post_destination,'no_data '),37," ") as 'post_destination                     ', count(origin) as '#devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, PD_auth_username, PD_auth_password, PD_user_login, PD_auth_token, PD_post_destination
+group by datetime, PD_auth_username, PD_auth_password, PD_user_login, PD_auth_token, PD_post_destination
 ;
 
 select "PogoDroid settings" as '';
 select
-date as 'date      ', rpad(ifnull(PD_boot_delay,'no_data '),10," ") as 'boot_delay', rpad(ifnull(PD_injection_delay,'no_data '),15," ") as 'injection_delay', rpad(ifnull(PD_switch_disable_last_sent,'no_data '),8," ") as 'lastSend', rpad(ifnull(PD_intentional_stop,'no_data '),10," ") as 'intentStop', rpad(ifnull(PD_switch_send_protos,'no_data '),9," ") as 'sendProto' ,rpad(ifnull(PD_switch_disable_external_communication,'no_data '),11," ") as 'disExtComms', rpad(ifnull(PD_switch_enable_oomadj,'no_data '),8," ") as 'enOomadj', rpad(ifnull(PD_switch_enable_auth_header,'no_data '),10," ") as 'enAuthHead', count(origin) as '#devices'
+datetime as 'datetime  ', rpad(ifnull(PD_boot_delay,'no_data '),10," ") as 'boot_delay', rpad(ifnull(PD_injection_delay,'no_data '),15," ") as 'injection_delay', rpad(ifnull(PD_switch_disable_last_sent,'no_data '),8," ") as 'lastSend', rpad(ifnull(PD_intentional_stop,'no_data '),10," ") as 'intentStop', rpad(ifnull(PD_switch_send_protos,'no_data '),9," ") as 'sendProto' ,rpad(ifnull(PD_switch_disable_external_communication,'no_data '),11," ") as 'disExtComms', rpad(ifnull(PD_switch_enable_oomadj,'no_data '),8," ") as 'enOomadj', rpad(ifnull(PD_switch_enable_auth_header,'no_data '),10," ") as 'enAuthHead', count(origin) as '#devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, PD_boot_delay, PD_injection_delay, PD_switch_disable_last_sent, PD_intentional_stop, PD_switch_send_protos, PD_switch_disable_external_communication, PD_switch_enable_oomadj, PD_switch_enable_auth_header;
+group by datetime, PD_boot_delay, PD_injection_delay, PD_switch_disable_last_sent, PD_intentional_stop, PD_switch_send_protos, PD_switch_disable_external_communication, PD_switch_enable_oomadj, PD_switch_enable_auth_header;
 
 select "PogoDroid settings" as '';
 select
-date as 'date      ', rpad(ifnull(PD_switch_send_raw_protos,'no_data '),11," ") as 'sendRawProto', rpad(ifnull(PD_switch_popup_last_sent,'no_data '),11," ") as 'popLastSend', rpad(ifnull(PD_full_daemon,'no_data '),10," ") as 'fullDaemon', rpad(ifnull(PD_switch_enable_mock_location_patch,'no_data '),6," ") as 'enMock', rpad(ifnull(PD_default_mappging_mode,'no_data '),10," ") as 'defMapMode', rpad(ifnull(PD_switch_setenforce,'no_data '),10," ") as 'setEnforce', rpad(ifnull(PD_disable_pogo_freeze_detection,'no_data '),13," ") as 'disPogoFreeze', count(origin) as '#devices'
+datetime as 'datetime  ', rpad(ifnull(PD_switch_send_raw_protos,'no_data '),11," ") as 'sendRawProto', rpad(ifnull(PD_switch_popup_last_sent,'no_data '),11," ") as 'popLastSend', rpad(ifnull(PD_full_daemon,'no_data '),10," ") as 'fullDaemon', rpad(ifnull(PD_switch_enable_mock_location_patch,'no_data '),6," ") as 'enMock', rpad(ifnull(PD_default_mappging_mode,'no_data '),10," ") as 'defMapMode', rpad(ifnull(PD_switch_setenforce,'no_data '),10," ") as 'setEnforce', rpad(ifnull(PD_disable_pogo_freeze_detection,'no_data '),13," ") as 'disPogoFreeze', count(origin) as '#devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, PD_switch_send_raw_protos, PD_switch_popup_last_sent, PD_full_daemon, PD_switch_enable_mock_location_patch, PD_default_mappging_mode, PD_switch_setenforce, PD_disable_pogo_freeze_detection
+group by datetime, PD_switch_send_raw_protos, PD_switch_popup_last_sent, PD_full_daemon, PD_switch_enable_mock_location_patch, PD_default_mappging_mode, PD_switch_setenforce, PD_disable_pogo_freeze_detection
 ;

--- a/sql/rgc_setting_overview.sql
+++ b/sql/rgc_setting_overview.sql
@@ -2,33 +2,33 @@ use pogodb
 
 select "RemoteGpsController settings" as '';
 select
-date as 'date      ', rpad(ifnull(RGC_auth_username,'no_data '),8," ") as 'username', rpad(ifnull(RGC_auth_password,'no_data '),11," ") as 'password   ', rpad(ifnull(RGC_websocket_uri,'no_data '),37," ") as 'websocket_url                     ', count(origin) as '#devices'
+datetime as 'datetime  ', rpad(ifnull(RGC_auth_username,'no_data '),8," ") as 'username', rpad(ifnull(RGC_auth_password,'no_data '),11," ") as 'password   ', rpad(ifnull(RGC_websocket_uri,'no_data '),37," ") as 'websocket_url                     ', count(origin) as '#devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, RGC_auth_username, RGC_auth_password, RGC_websocket_uri
+group by datetime, RGC_auth_username, RGC_auth_password, RGC_websocket_uri
 ;
 
 select "RemoteGpsController settings" as '';
 select
-date as 'date      ', rpad(ifnull(RGC_boot_delay,'no_data '),10," ") as 'boot_delay', rpad(ifnull(RGC_mediaprojection_previously_started,'no_data '),9," ") as 'mediaProj', rpad(ifnull(RGC_suspended_mocking,'no_data '),8," ") as 'suspMock', rpad(ifnull(RGC_reset_agps_once,'no_data '),8," ") as 'resAgps1', rpad(ifnull(RGC_overwrite_fused,'no_data '),10," ") as 'overwFused', rpad(ifnull(RGC_switch_enable_auth_header,'no_data '),10," ") as 'enAuthHead', rpad(ifnull(RGC_reset_agps_continuously,'no_data '),10," ") as 'resetAgpsC', count(origin) as '#devices'
+datetime as 'datetime  ', rpad(ifnull(RGC_boot_delay,'no_data '),10," ") as 'boot_delay', rpad(ifnull(RGC_mediaprojection_previously_started,'no_data '),9," ") as 'mediaProj', rpad(ifnull(RGC_suspended_mocking,'no_data '),8," ") as 'suspMock', rpad(ifnull(RGC_reset_agps_once,'no_data '),8," ") as 'resAgps1', rpad(ifnull(RGC_overwrite_fused,'no_data '),10," ") as 'overwFused', rpad(ifnull(RGC_switch_enable_auth_header,'no_data '),10," ") as 'enAuthHead', rpad(ifnull(RGC_reset_agps_continuously,'no_data '),10," ") as 'resetAgpsC', count(origin) as '#devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, RGC_boot_delay, RGC_mediaprojection_previously_started, RGC_suspended_mocking, RGC_reset_agps_once, RGC_overwrite_fused, RGC_switch_enable_auth_header, RGC_reset_agps_continuously
+group by datetime, RGC_boot_delay, RGC_mediaprojection_previously_started, RGC_suspended_mocking, RGC_reset_agps_once, RGC_overwrite_fused, RGC_switch_enable_auth_header, RGC_reset_agps_continuously
 ;
 
 select "RemoteGpsController settings" as '';
 select
-date as 'date      ', rpad(ifnull(RGC_reset_google_play_services,'no_data '),10," ") as 'resetGplay', rpad(ifnull(RGC_boot_startup,'no_data '),9," ") as 'bootStart', rpad(ifnull(RGC_use_mock_location,'no_data '),7," ") as 'useMock', rpad(ifnull(RGC_oom_adj_override,'no_data '),10," ") as 'overOomadj', rpad(ifnull(RGC_location_reporter_service_running,'no_data '),9," ") as 'locRepRun', rpad(ifnull(RGC_stop_location_provider_service,'no_data '),15," ") as 'stopLocProv', rpad(ifnull(RGC_autostart_services,'no_data '),11," ") as 'autoService', count(origin) as '#devices'
+datetime as 'datetime  ', rpad(ifnull(RGC_reset_google_play_services,'no_data '),10," ") as 'resetGplay', rpad(ifnull(RGC_boot_startup,'no_data '),9," ") as 'bootStart', rpad(ifnull(RGC_use_mock_location,'no_data '),7," ") as 'useMock', rpad(ifnull(RGC_oom_adj_override,'no_data '),10," ") as 'overOomadj', rpad(ifnull(RGC_location_reporter_service_running,'no_data '),9," ") as 'locRepRun', rpad(ifnull(RGC_stop_location_provider_service,'no_data '),15," ") as 'stopLocProv', rpad(ifnull(RGC_autostart_services,'no_data '),11," ") as 'autoService', count(origin) as '#devices'
 from ATVdetails
 
 where
-date = curdate() - interval XXA day
+date(datetime) = curdate() - interval XXA day
 
-group by date, RGC_reset_google_play_services, RGC_boot_startup, RGC_use_mock_location, RGC_oom_adj_override, RGC_location_reporter_service_running, RGC_stop_location_provider_service, RGC_autostart_services
+group by datetime, RGC_reset_google_play_services, RGC_boot_startup, RGC_use_mock_location, RGC_oom_adj_override, RGC_location_reporter_service_running, RGC_stop_location_provider_service, RGC_autostart_services
 ;

--- a/sql/temperature_details.sql
+++ b/sql/temperature_details.sql
@@ -29,7 +29,7 @@ datetime as 'datetime  ', rpad(origin,13," ") as 'origin      ', temperature
 from ATVdetails
 
 where
-date(datime) = curdate() - interval XXA day and
+date(datetime) = curdate() - interval XXA day and
 temperature is not NULL and
 temperature <> ''
 


### PR DESCRIPTION
Changes:
- on quaterly/hourly scripts reduce risk of read-locking tables causing possible falling behind on MAD
- adapat Stats menu to changes in ATVdetails

To update: git pull and execute settings.run

