### PR TITLE
spawndef15 cleanup incorrect when using redis server for MAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Available data:
 - missing proto received minutes  
 
 Additionally, not related to Stats, but you can optionally set:
-- cleanup op spawnpoint definitions in case they are f..... up by CommDay or Spotlight
+- cleanup op spawnpoint definitions in case they are f..... up by CommDay or Spotlight (does not work anymore if you use redis server for MAD)
 - move spawns discovered during quest scan outside mon area to seperate table and remove from trs_spawn
 - cleanup of trs_spawn for spawnpoint not seen for X days or after X days endtimes are still unknown
 - Remove spawnpoints ouside mon_mitm fences seen less then X times today

--- a/default_files/config.ini.example
+++ b/default_files/config.ini.example
@@ -77,7 +77,7 @@ SPAWN_NO_ENDTIME_DAYS=3					# number of days a spawnpoint is discovered yet no e
 SPAWN_UNFENCED_CLEANUP=false				# spawnpoint backup to statsdb.spawn_unused and remove from maddb.trs_spawn seen less then SPAWN_UNFENCED_TIMES times today
 SPAWN_UNFENCED_TIMES=3					# minimum number of times a spawnpoint OUTSIDE all monmitm fences has to be seen to keep it in trs_spawn else is will be backed up and removed 
 
-## Cleaup spawndef 15
+## Cleaup spawndef 15 (does not work anymore when using redis server for MAD as it will just reset all spawndef15 daily)
 SPAWNDEF15_CLEANUP=false				# daily reset incorrect hourly spawndefs. An hourly spawn must have been seen in first and second 30min period, based on yesterdays hourly data (after QUEST_END)
 SPAWNDEF15_HOURS=15					# number of hours spawnpoint has not been seen in first and second 30min period before resetting spawnpoint
 


### PR DESCRIPTION
in order to determine if spawndef 15 is correct I use first_scanned and last_modified to check if a mon is seen in the first and second 30 minute interval of spawndef 15.
With the introduction of redis server for MAD, column last_modified is not updated anymore resulting in every spawndef15 to be marked as incorrect hence reset during check.