### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Use it at you own risk, because bare in mind this was all done by an idiot!
 - Activation of (raw)stats in MAD config.ini (statistic,game_stats,game_stats_raw) and ``game_stats_save_time`` at default 300s
 - Mariadb 10.5
 - Mariadb to be installed on server Stats is running on
-- set max_heap_table_size in 50-server.cnf / my.cnf to 64M
+- set max_heap_table_size in 50-server.cnf / my.cnf to min. 64M
 - mysql strict mode disabled (should be done already for MAD)
 - Make sure ``jq`` is installed else,  ``sudo apt-get install jq``<BR>
 - Make sure unzip is installed <BR>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Use it at you own risk, because bare in mind this was all done by an idiot!
 - Activation of (raw)stats in MAD config.ini (statistic,game_stats,game_stats_raw) and ``game_stats_save_time`` at default 300s
 - Mariadb 10.5
 - Mariadb to be installed on server Stats is running on
-- set max_heap_table_size in 50-server.cnf / my.cnf to atleast 64M
+- set max_heap_table_size in 50-server.cnf / my.cnf to 64M
 - mysql strict mode disabled (should be done already for MAD)
 - Make sure ``jq`` is installed else,  ``sudo apt-get install jq``<BR>
 - Make sure unzip is installed <BR>

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Use it at you own risk, because bare in mind this was all done by an idiot!
 - Activation of (raw)stats in MAD config.ini (statistic,game_stats,game_stats_raw) and ``game_stats_save_time`` at default 300s
 - Mariadb 10.5
 - Mariadb to be installed on server Stats is running on
+- set max_heap_table_size in 50-server.cnf / my.cnf to atleast 64M
 - mysql strict mode disabled (should be done already for MAD)
 - Make sure ``jq`` is installed else,  ``sudo apt-get install jq``<BR>
 - Make sure unzip is installed <BR>


### PR DESCRIPTION
add additional finding for mariadb max_heap_table_size needs to be at least 64M for procedure mon_history_temp_backup_cleanup to complete. If its set to low you will get ERROR 1114 (HY000): The table '...' is full"